### PR TITLE
feat(go): add `BIGQUERY:type` field metadata

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -890,6 +890,8 @@ func buildField(schema *bigquery.FieldSchema, level uint) (arrow.Field, error) {
 	field.Nullable = !schema.Required
 	metadata["Type"] = string(schema.Type)
 
+	richSqlType := string(schema.Type)
+
 	if schema.PolicyTags != nil {
 		policyTagList, err := json.Marshal(schema.PolicyTags)
 		if err != nil {
@@ -920,14 +922,21 @@ func buildField(schema *bigquery.FieldSchema, level uint) (arrow.Field, error) {
 		field.Type = arrow.FixedWidthTypes.Timestamp_us
 	case bigquery.RecordFieldType:
 		nestedFields := make([]arrow.Field, len(schema.Schema))
+		nestedRichSqlTypes := make([]string, len(schema.Schema))
 		for i, nestedSchema := range schema.Schema {
 			f, err := buildField(nestedSchema, level+1)
 			if err != nil {
 				return arrow.Field{}, err
 			}
 			nestedFields[i] = f
+
+			fieldRichSqlType, found := f.Metadata.GetValue("BIGQUERY:type")
+			if found {
+				nestedRichSqlTypes[i] = fmt.Sprintf("%s %s", quoteIdentifier(f.Name), fieldRichSqlType)
+			}
 		}
 		structType := arrow.StructOf(nestedFields...)
+		richSqlType = fmt.Sprintf("STRUCT<%s>", strings.Join(nestedRichSqlTypes, ", "))
 		if structType == nil {
 			return arrow.Field{}, adbc.Error{
 				Code: adbc.StatusInvalidArgument,
@@ -1004,7 +1013,11 @@ func buildField(schema *bigquery.FieldSchema, level uint) (arrow.Field, error) {
 			Nullable: !schema.Required,
 			Metadata: arrow.MetadataFrom(childMetadata),
 		})
+		richSqlType = fmt.Sprintf("ARRAY<%s>", richSqlType)
 	}
+
+	// derive the standard type string from the field
+	metadata["BIGQUERY:type"] = richSqlType
 
 	if level == 0 {
 		metadata["DefaultValueExpression"] = schema.DefaultValueExpression

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -403,8 +403,10 @@ func (q *BigQueryQuirks) SampleTableSchemaMetadata(tblName string, dt arrow.Data
 		metadata["Collation"] = ""
 		metadata["MaxLength"] = "0"
 		metadata["Type"] = "STRING"
+		metadata["BIGQUERY:type"] = "STRING"
 	case arrow.INT64:
 		metadata["Type"] = "INTEGER"
+		metadata["BIGQUERY:type"] = "INTEGER"
 	}
 
 	return arrow.MetadataFrom(metadata)

--- a/go/schema_test.go
+++ b/go/schema_test.go
@@ -39,6 +39,7 @@ func (s *SchemaSuite) TestInt64() {
 	s.Equal("ints", field.Name)
 	s.Equal(arrow.INT64, field.Type.ID())
 	s.True(field.Nullable)
+	s.Equal("INTEGER", field.Metadata.ToMap()["BIGQUERY:type"])
 
 	field, err = buildField(&bigquery.FieldSchema{
 		Name:     "ints",
@@ -49,6 +50,7 @@ func (s *SchemaSuite) TestInt64() {
 	s.Equal("ints", field.Name)
 	s.Equal(arrow.INT64, field.Type.ID())
 	s.False(field.Nullable)
+	s.Equal("INTEGER", field.Metadata.ToMap()["BIGQUERY:type"])
 }
 
 func (s *SchemaSuite) TestListInt64() {
@@ -62,6 +64,7 @@ func (s *SchemaSuite) TestListInt64() {
 	s.Equal("ints", field.Name)
 	s.Truef(arrow.TypeEqual(expectedType, field.Type), field.Type.String())
 	s.True(field.Nullable)
+	s.Equal("ARRAY<INTEGER>", field.Metadata.ToMap()["BIGQUERY:type"])
 }
 
 func (s *SchemaSuite) TestListGeography() {
@@ -83,6 +86,7 @@ func (s *SchemaSuite) TestListGeography() {
 	s.True(ok)
 	s.Equal("geoarrow.wkt", ext)
 	s.True(field.Nullable)
+	s.Equal("ARRAY<GEOGRAPHY>", field.Metadata.ToMap()["BIGQUERY:type"])
 }
 
 func (s *SchemaSuite) TestStruct() {
@@ -131,6 +135,7 @@ func (s *SchemaSuite) TestStruct() {
 
 	ext, _ = record.Field(1).Type.(*arrow.ListType).ElemField().Metadata.GetValue("ARROW:extension:name")
 	s.Equal("arrow.json", ext)
+	s.Equal("STRUCT<`geo` GEOGRAPHY, `json` ARRAY<JSON>>", field.Metadata.ToMap()["BIGQUERY:type"])
 }
 
 func (s *SchemaSuite) TestStructList() {
@@ -157,6 +162,7 @@ func (s *SchemaSuite) TestStructList() {
 	s.Equal("record", field.Name)
 	s.Truef(arrow.TypeEqual(expectedType, field.Type), field.Type.String())
 	s.True(field.Nullable)
+	s.Equal("ARRAY<STRUCT<`ints` INTEGER>>", field.Metadata.ToMap()["BIGQUERY:type"])
 }
 
 func (s *SchemaSuite) TestNumeric() {
@@ -172,6 +178,7 @@ func (s *SchemaSuite) TestNumeric() {
 	s.Equal("decimals", field.Name)
 	s.Truef(arrow.TypeEqual(expectedType, field.Type), field.Type.String())
 	s.True(field.Nullable)
+	s.Equal("ARRAY<NUMERIC>", field.Metadata.ToMap()["BIGQUERY:type"])
 
 	// Ignore precision/scale because in terms of Arrow, we only ever get
 	// back data as decimal128(38, 9).  BigQuery's precision/scale is only
@@ -188,4 +195,5 @@ func (s *SchemaSuite) TestNumeric() {
 	s.Equal("decimals", field.Name)
 	s.Truef(arrow.TypeEqual(expectedType, field.Type), field.Type.String())
 	s.False(field.Nullable)
+	s.Equal("NUMERIC", field.Metadata.ToMap()["BIGQUERY:type"])
 }


### PR DESCRIPTION
## What's Changed

Cherry-pick of:
apache/arrow-adbc@6a82d7b55aba773219adadc3ebe436de86c4e9f6

Closes #7.
