### PR TITLE
feat(csharp): set AdbcException status to Unauthorized when unauthorized detected from server call

### DIFF
--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -91,7 +91,14 @@ namespace AdbcDrivers.BigQuery
 
         public override QueryResult ExecuteQuery()
         {
-            return ExecuteQueryInternalAsync().GetAwaiter().GetResult();
+            try
+            {
+                return ExecuteQueryInternalAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (BigQueryConnection.IsUnauthorizedException(ex, out GoogleApiException? googleEx))
+            {
+                throw new AdbcException(googleEx!.Message, AdbcStatusCode.Unauthorized, ex);
+            }
         }
 
         private async Task<QueryResult> ExecuteQueryInternalAsync()
@@ -252,7 +259,14 @@ namespace AdbcDrivers.BigQuery
 
         public override UpdateResult ExecuteUpdate()
         {
-            return ExecuteUpdateInternalAsync().GetAwaiter().GetResult();
+            try
+            {
+                return ExecuteUpdateInternalAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (BigQueryConnection.IsUnauthorizedException(ex, out GoogleApiException? googleEx))
+            {
+                throw new AdbcException(googleEx!.Message, AdbcStatusCode.Unauthorized, ex);
+            }
         }
 
         public override void Cancel()


### PR DESCRIPTION
## What's Changed

Sets the status on an `AdbcException` to be `Unauthorized` when we detect unauthorized access to the server

Closes #52 .
