### PR TITLE
fix(go): improve retries for waiting on jobs

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -326,7 +326,7 @@ func (c *connectionImpl) exec(ctx context.Context, stmt string, config func(*big
 	if err != nil {
 		return nil, err
 	}
-	status, err := safeWaitForJob(ctx, job)
+	status, err := safeWaitForJob(ctx, c.Logger, job)
 	if err != nil {
 		return nil, err
 	} else if err := status.Err(); err != nil {

--- a/go/statement.go
+++ b/go/statement.go
@@ -346,7 +346,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int6
 		}
 	}
 
-	rr, totalRows, err := newRecordReader(ctx, st.query(), st.params, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency)
+	rr, totalRows, err := newRecordReader(ctx, st.cnxn.Logger, st.query(), st.params, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency)
 	st.params = nil
 	return rr, totalRows, err
 }
@@ -360,7 +360,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 	}
 
 	if st.params == nil {
-		_, totalRows, err := runQuery(ctx, st.query(), true)
+		_, totalRows, err := runQuery(ctx, st.cnxn.Logger, st.query(), true)
 		if err != nil {
 			return -1, err
 		}
@@ -382,7 +382,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 					st.queryConfig.Parameters = parameters
 				}
 
-				_, currentRows, err := runQuery(ctx, st.query(), true)
+				_, currentRows, err := runQuery(ctx, st.cnxn.Logger, st.query(), true)
 				if err != nil {
 					return -1, err
 				}


### PR DESCRIPTION
## What's Changed

Fix another place where Google's SDK retries errors it shouldn't. Also, add backoff to the retries.

Closes #74.