### PR TITLE
fix: add timeout and disable option for BigQuery Storage Read API

### DIFF
--- a/go/bigquery_database.go
+++ b/go/bigquery_database.go
@@ -61,6 +61,15 @@ type databaseImpl struct {
 
 	bulkIngestMethod      string
 	bulkIngestCompression string
+
+	// disableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
+	// When true, falls back to the standard REST API.
+	// Useful in environments where HTTP/2 is blocked (e.g., SSL inspection proxies).
+	disableStorageReadClient bool
+
+	// storageReadAPIEndpoint overrides the Storage Read API gRPC endpoint.
+	// Empty string means use the default Google endpoint.
+	storageReadAPIEndpoint string
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
@@ -86,6 +95,8 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		quotaProject:               d.quotaProject,
 		bulkIngestMethod:           d.bulkIngestMethod,
 		bulkIngestCompression:      d.bulkIngestCompression,
+		disableStorageReadClient:   d.disableStorageReadClient,
+		storageReadAPIEndpoint:     d.storageReadAPIEndpoint,
 	}
 
 	err := conn.newClient(ctx)
@@ -148,6 +159,10 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 			return OptionValueCompressionNone, nil
 		}
 		return d.bulkIngestCompression, nil
+	case OptionBoolDisableStorageReadClient:
+		return strconv.FormatBool(d.disableStorageReadClient), nil
+	case OptionStringStorageReadAPIEndpoint:
+		return d.storageReadAPIEndpoint, nil
 	default:
 		return d.DatabaseImplBase.GetOption(key)
 	}
@@ -279,6 +294,17 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 			}
 		}
 		d.bulkIngestCompression = value
+	case OptionBoolDisableStorageReadClient:
+		val, err := strconv.ParseBool(value)
+		if err != nil {
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("[bq] invalid bool value for %s: %s", key, value),
+			}
+		}
+		d.disableStorageReadClient = val
+	case OptionStringStorageReadAPIEndpoint:
+		d.storageReadAPIEndpoint = value
 	default:
 		return d.DatabaseImplBase.SetOption(key, value)
 	}

--- a/go/bigquery_database.go
+++ b/go/bigquery_database.go
@@ -62,10 +62,11 @@ type databaseImpl struct {
 	bulkIngestMethod      string
 	bulkIngestCompression string
 
-	// disableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
-	// When true, falls back to the standard REST API.
-	// Useful in environments where HTTP/2 is blocked (e.g., SSL inspection proxies).
-	disableStorageReadClient bool
+	// queryBackendAPI selects which BigQuery API is used to read query results.
+	// Valid values: OptionValueQueryBackendAPIStorageRead (default), OptionValueQueryBackendAPIJobs.
+	// See issue #66. The REST fallback is not yet implemented; selecting "jobs"
+	// currently returns an error when results are read.
+	queryBackendAPI string
 
 	// storageReadAPIEndpoint overrides the Storage Read API gRPC endpoint.
 	// Empty string means use the default Google endpoint.
@@ -95,7 +96,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		quotaProject:               d.quotaProject,
 		bulkIngestMethod:           d.bulkIngestMethod,
 		bulkIngestCompression:      d.bulkIngestCompression,
-		disableStorageReadClient:   d.disableStorageReadClient,
+		queryBackendAPI:            d.queryBackendAPI,
 		storageReadAPIEndpoint:     d.storageReadAPIEndpoint,
 	}
 
@@ -159,8 +160,11 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 			return OptionValueCompressionNone, nil
 		}
 		return d.bulkIngestCompression, nil
-	case OptionBoolDisableStorageReadClient:
-		return strconv.FormatBool(d.disableStorageReadClient), nil
+	case OptionStringQueryBackendAPI:
+		if d.queryBackendAPI == "" {
+			return OptionValueQueryBackendAPIStorageRead, nil
+		}
+		return d.queryBackendAPI, nil
 	case OptionStringStorageReadAPIEndpoint:
 		return d.storageReadAPIEndpoint, nil
 	default:
@@ -294,15 +298,15 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 			}
 		}
 		d.bulkIngestCompression = value
-	case OptionBoolDisableStorageReadClient:
-		val, err := strconv.ParseBool(value)
-		if err != nil {
+	case OptionStringQueryBackendAPI:
+		if value != OptionValueQueryBackendAPIStorageRead &&
+			value != OptionValueQueryBackendAPIJobs {
 			return adbc.Error{
 				Code: adbc.StatusInvalidArgument,
-				Msg:  fmt.Sprintf("[bq] invalid bool value for %s: %s", key, value),
+				Msg:  fmt.Sprintf("[bq] invalid value for %s: %q (expected %q or %q)", key, value, OptionValueQueryBackendAPIStorageRead, OptionValueQueryBackendAPIJobs),
 			}
 		}
-		d.disableStorageReadClient = val
+		d.queryBackendAPI = value
 	case OptionStringStorageReadAPIEndpoint:
 		d.storageReadAPIEndpoint = value
 	default:

--- a/go/connection.go
+++ b/go/connection.go
@@ -82,10 +82,11 @@ type connectionImpl struct {
 	bulkIngestMethod      string
 	bulkIngestCompression string
 
-	// disableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
-	// When true, falls back to the standard REST API.
-	// Useful in environments where HTTP/2 is blocked (e.g., SSL inspection proxies).
-	disableStorageReadClient bool
+	// queryBackendAPI selects which BigQuery API is used to read query results.
+	// Valid values: OptionValueQueryBackendAPIStorageRead (default), OptionValueQueryBackendAPIJobs.
+	// See issue #66. The REST fallback is not yet implemented; selecting "jobs"
+	// currently returns an error when results are read.
+	queryBackendAPI string
 
 	// storageReadAPIEndpoint overrides the Storage Read API gRPC endpoint.
 	// Empty string means use the default Google endpoint.
@@ -683,15 +684,15 @@ func (c *connectionImpl) SetOption(key string, value string) error {
 			}
 		}
 		c.bulkIngestCompression = value
-	case OptionBoolDisableStorageReadClient:
-		val, err := strconv.ParseBool(value)
-		if err != nil {
+	case OptionStringQueryBackendAPI:
+		if value != OptionValueQueryBackendAPIStorageRead &&
+			value != OptionValueQueryBackendAPIJobs {
 			return adbc.Error{
 				Code: adbc.StatusInvalidArgument,
-				Msg:  fmt.Sprintf("[bq] invalid bool value for %s: %s", key, value),
+				Msg:  fmt.Sprintf("[bq] invalid value for %s: %q (expected %q or %q)", key, value, OptionValueQueryBackendAPIStorageRead, OptionValueQueryBackendAPIJobs),
 			}
 		}
-		c.disableStorageReadClient = val
+		c.queryBackendAPI = value
 	case OptionStringStorageReadAPIEndpoint:
 		c.storageReadAPIEndpoint = value
 	default:
@@ -853,11 +854,15 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		client.Location = c.location
 	}
 
-	// Use original authOptions without custom endpoint for Storage Read API.
 	// EnableStorageReadClient uses gRPC (HTTP/2) which may hang in environments
-	// where HTTP/2 is blocked (e.g., SSL inspection proxies). The option
-	// OptionBoolDisableStorageReadClient allows falling back to the REST API.
-	if !c.disableStorageReadClient {
+	// where HTTP/2 is blocked (e.g., SSL inspection proxies). Guard with a 30s
+	// timeout so the driver fails fast instead of hanging indefinitely.
+	//
+	// When OptionStringQueryBackendAPI is set to "jobs", we skip initialising
+	// the Storage Read client entirely. Note: the actual REST-based fallback
+	// for reading query results is not yet implemented (see issue #66); reads
+	// will return an explicit error in that case.
+	if c.queryBackendAPI != OptionValueQueryBackendAPIJobs {
 		storageCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		storageAuthOptions := authOptions
@@ -866,11 +871,12 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		}
 		if err := client.EnableStorageReadClient(storageCtx, storageAuthOptions...); err != nil {
 			if storageCtx.Err() != nil {
-				c.Logger.Warn("BigQuery Storage Read API timed out after 30s (possible HTTP/2 proxy issue), falling back to REST API. Set " + OptionBoolDisableStorageReadClient + "=true to skip this.")
+				c.Logger.Warn("BigQuery Storage Read API timed out after 30s (possible HTTP/2 proxy issue). Set " + OptionStringQueryBackendAPI + "=" + OptionValueQueryBackendAPIJobs + " to skip this once the REST fallback is implemented (issue #66).")
 			} else {
-				c.Logger.Warn("BigQuery Storage Read API unavailable, falling back to REST API", "err", err)
+				c.Logger.Warn("BigQuery Storage Read API unavailable", "err", err)
 			}
-			// non-fatal: continue without Storage Read API
+			// non-fatal: continue without Storage Read API; record_reader will
+			// surface an appropriate error when a caller tries to stream rows.
 		}
 	}
 

--- a/go/connection.go
+++ b/go/connection.go
@@ -854,9 +854,9 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		client.Location = c.location
 	}
 
-	// EnableStorageReadClient uses gRPC (HTTP/2) which may hang in environments
-	// where HTTP/2 is blocked (e.g., SSL inspection proxies). Guard with a 30s
-	// timeout so the driver fails fast instead of hanging indefinitely.
+	// EnableStorageReadClient opens a gRPC connection to the BigQuery Storage
+	// Read API. Guard with a 30s timeout so the driver fails fast instead of
+	// hanging indefinitely if the call does not return.
 	//
 	// When OptionStringQueryBackendAPI is set to "jobs", we skip initialising
 	// the Storage Read client entirely. Note: the actual REST-based fallback
@@ -871,7 +871,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		}
 		if err := client.EnableStorageReadClient(storageCtx, storageAuthOptions...); err != nil {
 			if storageCtx.Err() != nil {
-				c.Logger.Warn("BigQuery Storage Read API timed out after 30s (possible HTTP/2 proxy issue). Set " + OptionStringQueryBackendAPI + "=" + OptionValueQueryBackendAPIJobs + " to skip this once the REST fallback is implemented (issue #66).")
+				c.Logger.Warn("BigQuery Storage Read API timed out after 30s. See " + OptionStringQueryBackendAPI + " (issue #66) for the future REST fallback.")
 			} else {
 				c.Logger.Warn("BigQuery Storage Read API unavailable", "err", err)
 			}

--- a/go/connection.go
+++ b/go/connection.go
@@ -82,6 +82,16 @@ type connectionImpl struct {
 	bulkIngestMethod      string
 	bulkIngestCompression string
 
+	// disableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
+	// When true, falls back to the standard REST API.
+	// Useful in environments where HTTP/2 is blocked (e.g., SSL inspection proxies).
+	disableStorageReadClient bool
+
+	// storageReadAPIEndpoint overrides the Storage Read API gRPC endpoint.
+	// Empty string means use the default Google endpoint.
+	// Useful for testing with a local fake server or BigQuery emulator.
+	storageReadAPIEndpoint string
+
 	client *bigquery.Client
 }
 
@@ -673,6 +683,17 @@ func (c *connectionImpl) SetOption(key string, value string) error {
 			}
 		}
 		c.bulkIngestCompression = value
+	case OptionBoolDisableStorageReadClient:
+		val, err := strconv.ParseBool(value)
+		if err != nil {
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("[bq] invalid bool value for %s: %s", key, value),
+			}
+		}
+		c.disableStorageReadClient = val
+	case OptionStringStorageReadAPIEndpoint:
+		c.storageReadAPIEndpoint = value
 	default:
 		return c.ConnectionImplBase.SetOption(key, value)
 	}
@@ -832,10 +853,25 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		client.Location = c.location
 	}
 
-	// Use original authOptions without custom endpoint for Storage Read API
-	err = client.EnableStorageReadClient(ctx, authOptions...)
-	if err != nil {
-		return errToAdbcErr(adbc.StatusIO, err, "enable storage read client")
+	// Use original authOptions without custom endpoint for Storage Read API.
+	// EnableStorageReadClient uses gRPC (HTTP/2) which may hang in environments
+	// where HTTP/2 is blocked (e.g., SSL inspection proxies). The option
+	// OptionBoolDisableStorageReadClient allows falling back to the REST API.
+	if !c.disableStorageReadClient {
+		storageCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		storageAuthOptions := authOptions
+		if c.storageReadAPIEndpoint != "" {
+			storageAuthOptions = append(storageAuthOptions, option.WithEndpoint(c.storageReadAPIEndpoint))
+		}
+		if err := client.EnableStorageReadClient(storageCtx, storageAuthOptions...); err != nil {
+			if storageCtx.Err() != nil {
+				c.Logger.Warn("BigQuery Storage Read API timed out after 30s (possible HTTP/2 proxy issue), falling back to REST API. Set " + OptionBoolDisableStorageReadClient + "=true to skip this.")
+			} else {
+				c.Logger.Warn("BigQuery Storage Read API unavailable, falling back to REST API", "err", err)
+			}
+			// non-fatal: continue without Storage Read API
+		}
 	}
 
 	c.client = client

--- a/go/driver.go
+++ b/go/driver.go
@@ -71,10 +71,20 @@ const (
 	OptionStringQueryWriteDisposition  = "adbc.bigquery.sql.query.write_disposition"
 	OptionBoolQueryDisableQueryCache   = "adbc.bigquery.sql.query.disable_query_cache"
 
-	// OptionBoolDisableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
-	// When set to "true", the driver falls back to the standard REST API.
-	// Useful in environments where HTTP/2 is blocked or unavailable (e.g., SSL inspection proxies).
-	OptionBoolDisableStorageReadClient = "adbc.bigquery.sql.disable_storage_read_client"
+	// OptionStringQueryBackendAPI selects which BigQuery API is used to read
+	// query results. See issue #66 for design discussion.
+	//
+	// Valid values:
+	//   - OptionValueQueryBackendAPIStorageRead (default): use the Storage Read
+	//     API (gRPC/HTTP2). Required for Arrow-format streaming reads.
+	//   - OptionValueQueryBackendAPIJobs: select the REST Jobs API. NOTE: the
+	//     actual REST fallback is not yet implemented in this driver; setting
+	//     this value currently returns an error when reading results. The option
+	//     is added as infrastructure so callers can opt in once the fallback is
+	//     implemented in a follow-up PR.
+	OptionStringQueryBackendAPI             = "adbc.bigquery.query.backend_api"
+	OptionValueQueryBackendAPIStorageRead   = "storage_read"
+	OptionValueQueryBackendAPIJobs          = "jobs"
 
 	// OptionStringStorageReadAPIEndpoint overrides the endpoint used for the
 	// BigQuery Storage Read API (gRPC). Defaults to the public Google endpoint.

--- a/go/driver.go
+++ b/go/driver.go
@@ -70,6 +70,17 @@ const (
 	OptionStringQueryCreateDisposition = "adbc.bigquery.sql.query.create_disposition"
 	OptionStringQueryWriteDisposition  = "adbc.bigquery.sql.query.write_disposition"
 	OptionBoolQueryDisableQueryCache   = "adbc.bigquery.sql.query.disable_query_cache"
+
+	// OptionBoolDisableStorageReadClient disables the BigQuery Storage Read API (gRPC/HTTP2).
+	// When set to "true", the driver falls back to the standard REST API.
+	// Useful in environments where HTTP/2 is blocked or unavailable (e.g., SSL inspection proxies).
+	OptionBoolDisableStorageReadClient = "adbc.bigquery.sql.disable_storage_read_client"
+
+	// OptionStringStorageReadAPIEndpoint overrides the endpoint used for the
+	// BigQuery Storage Read API (gRPC). Defaults to the public Google endpoint.
+	// Useful for testing with a local fake server or BigQuery emulator.
+	// Format: "host:port" (e.g. "localhost:9443").
+	OptionStringStorageReadAPIEndpoint = "adbc.bigquery.sql.storage_read_api_endpoint"
 	OptionBoolDisableFlattenedResults  = "adbc.bigquery.sql.query.disable_flattened_results"
 	OptionBoolQueryAllowLargeResults   = "adbc.bigquery.sql.query.allow_large_results"
 	OptionStringQueryPriority          = "adbc.bigquery.sql.query.priority"

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1659,86 +1659,57 @@ func TestAuthTypeConsolidation(t *testing.T) {
 	}
 }
 
-func TestDisableStorageReadClientOption(t *testing.T) {
+func TestQueryBackendAPIOption(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
 	drv := driver.NewDriver(mem)
 
-	// Default value should be false
+	// Default value should be "storage_read".
 	db, err := drv.NewDatabase(nil)
-	if err != nil {
-		t.Fatalf("Failed to create database: %v", err)
-	}
+	require.NoError(t, err, "create database")
 	defer validation.CheckedClose(t, db)
 
 	getSetDB, ok := db.(adbc.GetSetOptions)
-	if !ok {
-		t.Fatal("Database does not implement adbc.GetSetOptions")
-	}
+	require.True(t, ok, "database should implement adbc.GetSetOptions")
 
-	val, err := getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
-	if err != nil {
-		t.Fatalf("Failed to get option: %v", err)
-	}
-	if val != "false" {
-		t.Errorf("Expected default value 'false', got '%s'", val)
-	}
+	val, err := getSetDB.GetOption(driver.OptionStringQueryBackendAPI)
+	require.NoError(t, err, "get default option")
+	assert.Equal(t, driver.OptionValueQueryBackendAPIStorageRead, val, "default backend")
 
-	// Setting true via SetOptions should work
-	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "true"})
-	if err != nil {
-		t.Fatalf("Failed to set option to true: %v", err)
-	}
-	val, err = getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
-	if err != nil {
-		t.Fatalf("Failed to get option: %v", err)
-	}
-	if val != "true" {
-		t.Errorf("Expected 'true', got '%s'", val)
-	}
+	// Setting "jobs" via SetOptions should work.
+	require.NoError(t,
+		db.SetOptions(map[string]string{driver.OptionStringQueryBackendAPI: driver.OptionValueQueryBackendAPIJobs}),
+		"set jobs backend")
+	val, err = getSetDB.GetOption(driver.OptionStringQueryBackendAPI)
+	require.NoError(t, err)
+	assert.Equal(t, driver.OptionValueQueryBackendAPIJobs, val)
 
-	// Setting false should work
-	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "false"})
-	if err != nil {
-		t.Fatalf("Failed to set option to false: %v", err)
-	}
-	val, err = getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
-	if err != nil {
-		t.Fatalf("Failed to get option: %v", err)
-	}
-	if val != "false" {
-		t.Errorf("Expected 'false', got '%s'", val)
-	}
+	// Setting "storage_read" explicitly should also work.
+	require.NoError(t,
+		db.SetOptions(map[string]string{driver.OptionStringQueryBackendAPI: driver.OptionValueQueryBackendAPIStorageRead}),
+		"set storage_read backend")
+	val, err = getSetDB.GetOption(driver.OptionStringQueryBackendAPI)
+	require.NoError(t, err)
+	assert.Equal(t, driver.OptionValueQueryBackendAPIStorageRead, val)
 
-	// Setting via NewDatabase should work
+	// Setting via NewDatabase should work.
 	db2, err := drv.NewDatabase(map[string]string{
-		driver.OptionBoolDisableStorageReadClient: "true",
+		driver.OptionStringQueryBackendAPI: driver.OptionValueQueryBackendAPIJobs,
 	})
-	if err != nil {
-		t.Fatalf("Failed to create database with option: %v", err)
-	}
+	require.NoError(t, err, "create database with option")
 	defer validation.CheckedClose(t, db2)
 
 	getSetDB2, ok := db2.(adbc.GetSetOptions)
-	if !ok {
-		t.Fatal("Database does not implement adbc.GetSetOptions")
-	}
-	val, err = getSetDB2.GetOption(driver.OptionBoolDisableStorageReadClient)
-	if err != nil {
-		t.Fatalf("Failed to get option from db2: %v", err)
-	}
-	if val != "true" {
-		t.Errorf("Expected 'true' from NewDatabase, got '%s'", val)
-	}
+	require.True(t, ok)
+	val, err = getSetDB2.GetOption(driver.OptionStringQueryBackendAPI)
+	require.NoError(t, err)
+	assert.Equal(t, driver.OptionValueQueryBackendAPIJobs, val)
 
-	// Invalid value should return an error
-	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "not-a-bool"})
-	if err == nil {
-		t.Error("Expected error for invalid bool value")
-	} else if !strings.Contains(err.Error(), "invalid bool value") {
-		t.Errorf("Expected error message to contain 'invalid bool value', got: %v", err)
-	}
+	// Invalid value should return an error.
+	err = db.SetOptions(map[string]string{driver.OptionStringQueryBackendAPI: "rest"})
+	require.Error(t, err, "invalid value should error")
+	assert.Contains(t, err.Error(), "invalid value")
 }
 
 type BigQueryTestSuite struct {

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1659,6 +1659,88 @@ func TestAuthTypeConsolidation(t *testing.T) {
 	}
 }
 
+func TestDisableStorageReadClientOption(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	drv := driver.NewDriver(mem)
+
+	// Default value should be false
+	db, err := drv.NewDatabase(nil)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer validation.CheckedClose(t, db)
+
+	getSetDB, ok := db.(adbc.GetSetOptions)
+	if !ok {
+		t.Fatal("Database does not implement adbc.GetSetOptions")
+	}
+
+	val, err := getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
+	if err != nil {
+		t.Fatalf("Failed to get option: %v", err)
+	}
+	if val != "false" {
+		t.Errorf("Expected default value 'false', got '%s'", val)
+	}
+
+	// Setting true via SetOptions should work
+	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "true"})
+	if err != nil {
+		t.Fatalf("Failed to set option to true: %v", err)
+	}
+	val, err = getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
+	if err != nil {
+		t.Fatalf("Failed to get option: %v", err)
+	}
+	if val != "true" {
+		t.Errorf("Expected 'true', got '%s'", val)
+	}
+
+	// Setting false should work
+	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "false"})
+	if err != nil {
+		t.Fatalf("Failed to set option to false: %v", err)
+	}
+	val, err = getSetDB.GetOption(driver.OptionBoolDisableStorageReadClient)
+	if err != nil {
+		t.Fatalf("Failed to get option: %v", err)
+	}
+	if val != "false" {
+		t.Errorf("Expected 'false', got '%s'", val)
+	}
+
+	// Setting via NewDatabase should work
+	db2, err := drv.NewDatabase(map[string]string{
+		driver.OptionBoolDisableStorageReadClient: "true",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create database with option: %v", err)
+	}
+	defer validation.CheckedClose(t, db2)
+
+	getSetDB2, ok := db2.(adbc.GetSetOptions)
+	if !ok {
+		t.Fatal("Database does not implement adbc.GetSetOptions")
+	}
+	val, err = getSetDB2.GetOption(driver.OptionBoolDisableStorageReadClient)
+	if err != nil {
+		t.Fatalf("Failed to get option from db2: %v", err)
+	}
+	if val != "true" {
+		t.Errorf("Expected 'true' from NewDatabase, got '%s'", val)
+	}
+
+	// Invalid value should return an error
+	err = db.SetOptions(map[string]string{driver.OptionBoolDisableStorageReadClient: "not-a-bool"})
+	if err == nil {
+		t.Error("Expected error for invalid bool value")
+	} else if !strings.Contains(err.Error(), "invalid bool value") {
+		t.Errorf("Expected error message to contain 'invalid bool value', got: %v", err)
+	}
+}
+
 type BigQueryTestSuite struct {
 	suite.Suite
 	project string

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -138,12 +138,12 @@ func runQuery(ctx context.Context, logger *slog.Logger, queryBackendAPI string, 
 		}
 
 		// ArrowIterator() opens a gRPC read session via BigQuery Storage API
-		// (CreateReadSession RPC). In environments where HTTP/2 is blocked
-		// (e.g. VPN with SSL inspection proxy), this call hangs indefinitely.
-		// We apply a 30s timeout so the caller gets a clear error instead of
-		// blocking forever. The goroutine may outlive the timeout if the
-		// underlying gRPC connection does not respect context cancellation,
-		// but it will be cleaned up when the connection is closed.
+		// (CreateReadSession RPC). The call does not accept a context, and
+		// has been observed to hang indefinitely in some environments. Apply
+		// a 30s timeout so the caller gets a clear error instead of blocking
+		// forever. The goroutine may outlive the timeout since the underlying
+		// gRPC call cannot be cancelled from here, but it will be cleaned up
+		// when the connection is closed.
 		type arrowIterResult struct {
 			ai  bigquery.ArrowIterator
 			err error
@@ -175,8 +175,6 @@ func runQuery(ctx context.Context, logger *slog.Logger, queryBackendAPI string, 
 			return nil, -1, adbc.Error{
 				Code: adbc.StatusTimeout,
 				Msg: "[bq] BigQuery Storage Read API timed out after 30s. " +
-					"This may be caused by HTTP/2 being blocked by a VPN or SSL inspection proxy, " +
-					"or by running the driver inside a c-shared DLL where the gRPC stream stalls. " +
 					"See " + OptionStringQueryBackendAPI + " (issue #66) for the future REST fallback.",
 			}
 		}

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -63,7 +63,19 @@ func checkContext(ctx context.Context, maybeErr error) error {
 	return ctx.Err()
 }
 
-func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, executeUpdate bool) (bigquery.ArrowIterator, int64, error) {
+func runQuery(ctx context.Context, logger *slog.Logger, queryBackendAPI string, query *bigquery.Query, executeUpdate bool) (bigquery.ArrowIterator, int64, error) {
+	// Jobs API backend is not yet implemented (see issue #66). Fail fast with
+	// a clear error rather than hanging or returning a misleading permission
+	// error downstream.
+	if !executeUpdate && queryBackendAPI == OptionValueQueryBackendAPIJobs {
+		return nil, -1, adbc.Error{
+			Code: adbc.StatusNotImplemented,
+			Msg: "[bq] " + OptionStringQueryBackendAPI + "=" + OptionValueQueryBackendAPIJobs +
+				" is not yet implemented. The REST-based fallback for reading query results has not been added to this driver (see issue #66). " +
+				"Use " + OptionStringQueryBackendAPI + "=" + OptionValueQueryBackendAPIStorageRead + " (the default) until the fallback is available.",
+		}
+	}
+
 	job, err := query.Run(ctx)
 	if err != nil {
 		return nil, -1, errToAdbcErr(adbc.StatusInternal, err, "run query")
@@ -163,8 +175,9 @@ func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, e
 			return nil, -1, adbc.Error{
 				Code: adbc.StatusTimeout,
 				Msg: "[bq] BigQuery Storage Read API timed out after 30s. " +
-					"This may be caused by HTTP/2 being blocked by a VPN or SSL inspection proxy. " +
-					"Set " + OptionBoolDisableStorageReadClient + "=true to disable the Storage Read API.",
+					"This may be caused by HTTP/2 being blocked by a VPN or SSL inspection proxy, " +
+					"or by running the driver inside a c-shared DLL where the gRPC stream stalls. " +
+					"See " + OptionStringQueryBackendAPI + " (issue #66) for the future REST fallback.",
 			}
 		}
 	} else {
@@ -209,8 +222,8 @@ func getQueryParameter(values arrow.RecordBatch, row int, parameterMode string) 
 	return parameters, nil
 }
 
-func runPlainQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, alloc memory.Allocator, resultRecordBufferSize int) (bigqueryRdr *reader, totalRows int64, err error) {
-	arrowIterator, totalRows, err := runQuery(ctx, logger, query, false)
+func runPlainQuery(ctx context.Context, logger *slog.Logger, queryBackendAPI string, query *bigquery.Query, alloc memory.Allocator, resultRecordBufferSize int) (bigqueryRdr *reader, totalRows int64, err error) {
+	arrowIterator, totalRows, err := runQuery(ctx, logger, queryBackendAPI, query, false)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -255,7 +268,7 @@ func runPlainQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Que
 	return bigqueryRdr, totalRows, nil
 }
 
-func queryRecordWithSchemaCallback(ctx context.Context, logger *slog.Logger, group *errgroup.Group, query *bigquery.Query, rec arrow.RecordBatch, ch chan arrow.RecordBatch, parameterMode string, alloc memory.Allocator, rdrSchema func(schema *arrow.Schema)) (int64, error) {
+func queryRecordWithSchemaCallback(ctx context.Context, logger *slog.Logger, queryBackendAPI string, group *errgroup.Group, query *bigquery.Query, rec arrow.RecordBatch, ch chan arrow.RecordBatch, parameterMode string, alloc memory.Allocator, rdrSchema func(schema *arrow.Schema)) (int64, error) {
 	totalRows := int64(-1)
 	for i := range int(rec.NumRows()) {
 		parameters, err := getQueryParameter(rec, i, parameterMode)
@@ -266,7 +279,7 @@ func queryRecordWithSchemaCallback(ctx context.Context, logger *slog.Logger, gro
 			query.Parameters = parameters
 		}
 
-		arrowIterator, rows, err := runQuery(ctx, logger, query, false)
+		arrowIterator, rows, err := runQuery(ctx, logger, queryBackendAPI, query, false)
 		if err != nil {
 			return -1, err
 		}
@@ -291,9 +304,9 @@ func queryRecordWithSchemaCallback(ctx context.Context, logger *slog.Logger, gro
 
 // kicks off a goroutine for each endpoint and returns a reader which
 // gathers all of the records as they come in.
-func newRecordReader(ctx context.Context, logger *slog.Logger, query *bigquery.Query, boundParameters array.RecordReader, parameterMode string, alloc memory.Allocator, resultRecordBufferSize, prefetchConcurrency int) (bigqueryRdr *reader, totalRows int64, err error) {
+func newRecordReader(ctx context.Context, logger *slog.Logger, queryBackendAPI string, query *bigquery.Query, boundParameters array.RecordReader, parameterMode string, alloc memory.Allocator, resultRecordBufferSize, prefetchConcurrency int) (bigqueryRdr *reader, totalRows int64, err error) {
 	if boundParameters == nil {
-		return runPlainQuery(ctx, logger, query, alloc, resultRecordBufferSize)
+		return runPlainQuery(ctx, logger, queryBackendAPI, query, alloc, resultRecordBufferSize)
 	}
 	defer boundParameters.Release()
 
@@ -329,7 +342,7 @@ func newRecordReader(ctx context.Context, logger *slog.Logger, query *bigquery.Q
 		// Each call to Record() on the record reader is allowed to release the previous record
 		// and since we're doing this sequentially
 		// we don't need to call rec.Retain() here and call call rec.Release() in queryRecordWithSchemaCallback
-		batchRows, err := queryRecordWithSchemaCallback(ctx, logger, group, query, rec, ch, parameterMode, alloc, func(schema *arrow.Schema) {
+		batchRows, err := queryRecordWithSchemaCallback(ctx, logger, queryBackendAPI, group, query, rec, ch, parameterMode, alloc, func(schema *arrow.Schema) {
 			bigqueryRdr.schema = schema
 		})
 		if err != nil {

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -26,9 +26,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"log/slog"
 	"sync/atomic"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -122,8 +124,48 @@ func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, e
 				Msg:  "[bq] Arrow reader requires roles/bigquery.readSessionUser, see https://github.com/apache/arrow-adbc/issues/3282",
 			}
 		}
-		if arrowIterator, err = iter.ArrowIterator(); err != nil {
-			return nil, -1, errToAdbcErr(adbc.StatusInternal, err, "read Arrow query results")
+
+		// ArrowIterator() opens a gRPC read session via BigQuery Storage API
+		// (CreateReadSession RPC). In environments where HTTP/2 is blocked
+		// (e.g. VPN with SSL inspection proxy), this call hangs indefinitely.
+		// We apply a 30s timeout so the caller gets a clear error instead of
+		// blocking forever. The goroutine may outlive the timeout if the
+		// underlying gRPC connection does not respect context cancellation,
+		// but it will be cleaned up when the connection is closed.
+		type arrowIterResult struct {
+			ai  bigquery.ArrowIterator
+			err error
+		}
+		ch := make(chan arrowIterResult, 1)
+		go func() {
+			ai, err := iter.ArrowIterator()
+			ch <- arrowIterResult{ai, err}
+		}()
+
+		storageCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		select {
+		case r := <-ch:
+			if r.err != nil {
+				return nil, -1, errToAdbcErr(adbc.StatusInternal, r.err, "read Arrow query results")
+			}
+			arrowIterator = r.ai
+		case <-storageCtx.Done():
+			if ctx.Err() != nil {
+				// Parent context was cancelled by the caller — propagate it.
+				return nil, -1, adbc.Error{
+					Code: adbc.StatusCancelled,
+					Msg:  fmt.Sprintf("[bq] context cancelled while opening BigQuery Storage read session: %s", ctx.Err()),
+				}
+			}
+			// Our own 30s timeout fired — the Storage Read API is unreachable.
+			return nil, -1, adbc.Error{
+				Code: adbc.StatusTimeout,
+				Msg: "[bq] BigQuery Storage Read API timed out after 30s. " +
+					"This may be caused by HTTP/2 being blocked by a VPN or SSL inspection proxy. " +
+					"Set " + OptionBoolDisableStorageReadClient + "=true to disable the Storage Read API.",
+			}
 		}
 	} else {
 		arrowIterator = emptyArrowIterator{iter.Schema}

--- a/go/statement.go
+++ b/go/statement.go
@@ -382,7 +382,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int6
 		}
 	}
 
-	rr, totalRows, err := newRecordReader(ctx, st.cnxn.Logger, st.query(), st.params, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency)
+	rr, totalRows, err := newRecordReader(ctx, st.cnxn.Logger, st.cnxn.queryBackendAPI, st.query(), st.params, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency)
 	st.params = nil
 	return rr, totalRows, err
 }
@@ -396,7 +396,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 	}
 
 	if st.params == nil {
-		_, totalRows, err := runQuery(ctx, st.cnxn.Logger, st.query(), true)
+		_, totalRows, err := runQuery(ctx, st.cnxn.Logger, st.cnxn.queryBackendAPI, st.query(), true)
 		if err != nil {
 			return -1, err
 		}
@@ -418,7 +418,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 					st.queryConfig.Parameters = parameters
 				}
 
-				_, currentRows, err := runQuery(ctx, st.cnxn.Logger, st.query(), true)
+				_, currentRows, err := runQuery(ctx, st.cnxn.Logger, st.cnxn.queryBackendAPI, st.query(), true)
 				if err != nil {
 					return -1, err
 				}


### PR DESCRIPTION
# fix: add timeout on BigQuery Storage Read API gRPC session to prevent indefinite hang

### Problem

When the BigQuery Storage Read API is used (default), the driver can hang indefinitely during query execution. The exact hang point is iter.ArrowIterator(), which issues a gRPC CreateReadSession RPC to bigquerystorage.googleapis.com.

This occurs in environments where HTTP/2 (required by gRPC) is silently blocked — most commonly consumer VPNs and SSL-inspection proxies. The TCP handshake to the storage endpoint succeeds (making the connection appear live), but the gRPC call never completes and no error is returned.

### Reproduction

Confirmed with [dbt Fusion](https://docs.getdbt.com/docs/core/installation-overview) + hidemy.name VPN (AWS EC2, Frankfurt/Estonia exit nodes):

Without VPN — completes in 2.4s, fails fast with 403 (IP restriction)
TCP connects to 142.250.x.x (Google), gRPC never reached
dbtf debug
With VPN — hangs indefinitely, no error, no timeout
TCP connects, gRPC CreateReadSession never returns
dbtf debug    ← stuck here forever
Debug logs confirm the query itself executes successfully (select 1 as id) before the hang — the problem is exclusively in opening the Storage Read session for streaming results.

### Root cause

bigquery.RowIterator.ArrowIterator() issues a CreateReadSession gRPC call with no deadline. In environments where HTTP/2 is transparently blocked (VPN, proxy), the call blocks forever.

EnableStorageReadClient() itself is not the issue — it creates a lazy stub and returns immediately.

### Fix

record_reader.go — wraps iter.ArrowIterator() in a goroutine with a 30-second context.WithTimeout. On timeout, returns an adbc.StatusTimeout error with an explicit message directing users to set OptionBoolDisableStorageReadClient=true.
connection.go — adds disableStorageReadClient and storageReadAPIEndpoint fields; skips EnableStorageReadClient() when disabled; supports custom gRPC endpoint for testing/emulators.
bigquery_database.go — exposes both options at the database level with GetOption/SetOption.
driver.go — declares the two new option constants.
driver_test.go — adds TestDisableStorageReadClientOption verifying default value, set/unset, construction via NewDatabase, and rejection of invalid values.
Error message shown to users on timeout

[bq] BigQuery Storage Read API timed out after 30s.
This may be caused by HTTP/2 being blocked by a VPN or SSL inspection proxy.
Set adbc.bigquery.sql.disable_storage_read_client=true to disable the Storage Read API.

### Notes

The 30s timeout is intentionally generous; most healthy environments complete CreateReadSession in under 1s.
disable_storage_read_client=true currently falls back to non-Arrow row iteration (no REST→Arrow path yet); this is a known limitation noted in the option docs.
storage_read_api_endpoint is included for emulator/local testing compatibility. 

Related upstream issue: [dbt-labs/dbt-core#14470](https://github.com/dbt-labs/dbt-core/issues/14470) — HTTPS_PROXY/NO_PROXY environment variables are ignored by the Go ADBC network stack, which means proxy-based workarounds are not available to affected users.

This issue surfaces specifically with dbt Fusion: dbt Core works correctly under the same VPN (queries complete successfully). Without VPN, standard dbt build runs fail with a database error — likely due to IP allowlist restrictions on the BigQuery project — so VPN is a required part of the setup for affected users, not an optional workaround. The hang described here is therefore a real blocker, not an edge case.

Also i didn't build full project (dbt fusion) with this fix. I will be grateful if anyone help me with that