### PR TITLE
fix(csharp): add more logic around retries with expired tokens

### DIFF
--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -1552,19 +1552,8 @@ namespace AdbcDrivers.BigQuery
                                     await this.clientMgr.UpdateToken().ConfigureAwait(false);
                                     activity?.AddEvent("token_refresh_completed");
 
-                                    // Dispose the old stream and reconnect with the refreshed client
-                                    try
-                                    {
-                                        await this.response!.DisposeAsync().ConfigureAwait(false);
-                                    }
-                                    catch
-                                    {
-                                        // Best-effort disposal of the broken stream
-                                    }
-                                    this.response = CreateEnumerator(this.rowsRead, effectiveToken);
-                                    activity?.AddEvent("stream_reconnected_after_token_refresh", [
-                                        new("stream.name", this.streamName),
-                                        new("stream.row_offset", this.rowsRead),
+                                    await ReconnectStreamAsync("token_refresh", effectiveToken, activity, [
+                                        new("token_refresh.attempt", tokenRefreshCount),
                                     ]);
                                     continue;
                                 }
@@ -1593,19 +1582,7 @@ namespace AdbcDrivers.BigQuery
                             await Task.Delay(delay, effectiveToken).ConfigureAwait(false);
                             delay = Math.Min(2 * delay, 5000);
 
-                            // Re-create the gRPC stream starting from the offset of rows already read
-                            try
-                            {
-                                await this.response.DisposeAsync().ConfigureAwait(false);
-                            }
-                            catch
-                            {
-                                // Best-effort disposal of the broken stream
-                            }
-                            this.response = CreateEnumerator(this.rowsRead, effectiveToken);
-                            activity?.AddEvent("stream_reconnected", [
-                                new("stream.name", this.streamName),
-                                new("stream.row_offset", this.rowsRead),
+                            await ReconnectStreamAsync("general_retry", effectiveToken, activity, [
                                 new("retry.attempt", retryCount),
                             ]);
                         }
@@ -1622,6 +1599,53 @@ namespace AdbcDrivers.BigQuery
                         }
                     }
                 }, ClassName + "." + nameof(MoveNextWithRetryAsync));
+            }
+
+            /// <summary>
+            /// Disposes the current stream (best-effort) and creates a new enumerator starting from the current row offset.
+            /// </summary>
+            /// <param name="context">A description of why reconnection is happening (e.g., "token_refresh", "general_retry").</param>
+            /// <param name="effectiveToken">The cancellation token to use for the new stream.</param>
+            /// <param name="activity">Optional activity for telemetry.</param>
+            /// <param name="additionalTags">Optional additional tags to include in the reconnection event.</param>
+            private async Task ReconnectStreamAsync(
+                string context,
+                CancellationToken effectiveToken,
+                Activity? activity,
+                IEnumerable<KeyValuePair<string, object?>>? additionalTags = null)
+            {
+                // Dispose the old stream (best-effort)
+                try
+                {
+                    await this.response!.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception disposeEx)
+                {
+                    // Log disposal failure but don't fail the reconnection
+                    activity?.AddEvent("stream_dispose_failed", [
+                        new("stream.name", this.streamName),
+                        new("stream.row_offset", this.rowsRead),
+                        new("dispose.context", context),
+                        new("dispose.exception_type", disposeEx.GetType().Name),
+                        new("dispose.exception_message", disposeEx.Message),
+                    ]);
+                }
+
+                // Create new enumerator starting from current offset
+                this.response = CreateEnumerator(this.rowsRead, effectiveToken);
+
+                // Log the reconnection
+                var tags = new List<KeyValuePair<string, object?>>
+                {
+                    new("stream.name", this.streamName),
+                    new("stream.row_offset", this.rowsRead),
+                    new("reconnect.context", context),
+                };
+                if (additionalTags != null)
+                {
+                    tags.AddRange(additionalTags);
+                }
+                activity?.AddEvent("stream_reconnected", tags);
             }
 
             private IAsyncEnumerator<ReadRowsResponse> CreateEnumerator(long offset, CancellationToken effectiveToken)

--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -41,7 +41,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2.Data;
 using Google.Cloud.BigQuery.Storage.V1;
 using Google.Cloud.BigQuery.V2;
-using Grpc.Core;
 using TableFieldSchema = Google.Apis.Bigquery.v2.Data.TableFieldSchema;
 using TableSchema = Google.Apis.Bigquery.v2.Data.TableSchema;
 

--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -1518,6 +1518,7 @@ namespace AdbcDrivers.BigQuery
                     }
 
                     int retryCount = 0;
+                    int tokenRefreshCount = 0;
                     int delay = this.initialDelayMs;
 
                     while (true)
@@ -1536,13 +1537,17 @@ namespace AdbcDrivers.BigQuery
                             // For OAuth: trades refresh_token for a new access token.
                             // For Entra ID: re-trades the (hopefully still valid) Entra token at Google STS.
                             // For service account: re-mints from the JSON private key.
-                            if (this.clientMgr.UpdateToken != null)
+                            // Token refresh attempts are tracked separately from general retries
+                            // to avoid double-counting when both error types occur.
+                            if (this.clientMgr.UpdateToken != null && tokenRefreshCount < maxRetries)
                             {
+                                tokenRefreshCount++;
                                 try
                                 {
                                     activity?.AddEvent("token_refresh_started", [
                                         new("stream.name", this.streamName),
                                         new("stream.row_offset", this.rowsRead),
+                                        new("token_refresh.attempt", tokenRefreshCount),
                                     ]);
                                     await this.clientMgr.UpdateToken().ConfigureAwait(false);
                                     activity?.AddEvent("token_refresh_completed");
@@ -1568,6 +1573,7 @@ namespace AdbcDrivers.BigQuery
                                     // Token refresh failed (e.g., Entra ID token also expired).
                                     activity?.AddException(refreshEx, [
                                         new KeyValuePair<string, object?>("token_refresh.failed", true),
+                                        new KeyValuePair<string, object?>("token_refresh.attempt", tokenRefreshCount),
                                     ]);
                                 }
                             }

--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -156,7 +156,8 @@ namespace AdbcDrivers.BigQuery
                     return await ExecuteMetadataCommandQuery(activity);
                 }
 
-                BigQueryJob job = await Client.CreateQueryJobAsync(SqlQuery, null, queryOptions);
+                BigQueryJob job = await ExecuteWithRetriesAsync(
+                    () => Client.CreateQueryJobAsync(SqlQuery, null, queryOptions), activity).ConfigureAwait(false);
                 JobReference jobReference = job.Reference;
                 GetQueryResultsOptions getQueryResultsOptions = new GetQueryResultsOptions();
 
@@ -742,7 +743,7 @@ namespace AdbcDrivers.BigQuery
             foreach (var stream in rrs.Streams)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                readers.Add(new ReadRowsStream(this, bigQueryReadClient, stream.Name, MaxRetryAttempts, RetryDelayMs, cancellationToken));
+                readers.Add(new ReadRowsStream(this, clientMgr, stream.Name, MaxRetryAttempts, RetryDelayMs, cancellationToken));
             }
 
             return readers;
@@ -1447,7 +1448,7 @@ namespace AdbcDrivers.BigQuery
         sealed class ReadRowsStream : IArrowArrayStream
         {
             readonly IActivityTracer tracer;
-            readonly BigQueryReadClient client;
+            readonly TokenProtectedReadClientManger clientMgr;
             readonly string streamName;
             readonly int maxRetries;
             readonly int initialDelayMs;
@@ -1458,10 +1459,10 @@ namespace AdbcDrivers.BigQuery
             bool initialized;
             bool disposed;
 
-            public ReadRowsStream(IActivityTracer tracer, BigQueryReadClient client, string streamName, int maxRetries, int initialDelayMs, CancellationToken cancellationToken)
+            public ReadRowsStream(IActivityTracer tracer, TokenProtectedReadClientManger clientMgr, string streamName, int maxRetries, int initialDelayMs, CancellationToken cancellationToken)
             {
                 this.tracer = tracer;
-                this.client = client;
+                this.clientMgr = clientMgr;
                 this.streamName = streamName;
                 this.maxRetries = maxRetries;
                 this.initialDelayMs = initialDelayMs;
@@ -1530,6 +1531,53 @@ namespace AdbcDrivers.BigQuery
                         {
                             throw;
                         }
+                        catch (Exception ex) when (BigQueryUtils.IsGrpcUnauthenticated(ex))
+                        {
+                            // Try to refresh the Google access token and reconnect.
+                            // For OAuth: trades refresh_token for a new access token.
+                            // For Entra ID: re-trades the (hopefully still valid) Entra token at Google STS.
+                            // For service account: re-mints from the JSON private key.
+                            if (this.clientMgr.UpdateToken != null)
+                            {
+                                try
+                                {
+                                    activity?.AddEvent("token_refresh_started", [
+                                        new("stream.name", this.streamName),
+                                        new("stream.row_offset", this.rowsRead),
+                                    ]);
+                                    await this.clientMgr.UpdateToken().ConfigureAwait(false);
+                                    activity?.AddEvent("token_refresh_completed");
+
+                                    // Dispose the old stream and reconnect with the refreshed client
+                                    try
+                                    {
+                                        await this.response!.DisposeAsync().ConfigureAwait(false);
+                                    }
+                                    catch
+                                    {
+                                        // Best-effort disposal of the broken stream
+                                    }
+                                    this.response = CreateEnumerator(this.rowsRead, effectiveToken);
+                                    activity?.AddEvent("stream_reconnected_after_token_refresh", [
+                                        new("stream.name", this.streamName),
+                                        new("stream.row_offset", this.rowsRead),
+                                    ]);
+                                    continue;
+                                }
+                                catch (Exception refreshEx)
+                                {
+                                    // Token refresh failed (e.g., Entra ID token also expired).
+                                    activity?.AddException(refreshEx, [
+                                        new KeyValuePair<string, object?>("token_refresh.failed", true),
+                                    ]);
+                                }
+                            }
+
+                            throw new AdbcException(
+                                $"Authentication failed reading stream '{this.streamName}' at row offset {this.rowsRead}. {ex.GetType().Name}: {ex.Message}",
+                                AdbcStatusCode.Unauthenticated,
+                                ex);
+                        }
                         catch (Exception ex) when (retryCount < this.maxRetries)
                         {
                             activity?.AddException(ex, BigQueryUtils.BuildExceptionTagList(retryCount, ex, [
@@ -1558,9 +1606,13 @@ namespace AdbcDrivers.BigQuery
                         }
                         catch (Exception ex)
                         {
+                            AdbcStatusCode statusCode = BigQueryUtils.IsGrpcUnauthenticated(ex)
+                                ? AdbcStatusCode.Unauthenticated
+                                : AdbcStatusCode.IOError;
+
                             throw new AdbcException(
                                 $"Cannot read stream '{this.streamName}' after {this.maxRetries} retries at row offset {this.rowsRead}. Last exception: {ex.GetType().Name}: {ex.Message}",
-                                AdbcStatusCode.IOError,
+                                statusCode,
                                 ex);
                         }
                     }
@@ -1569,7 +1621,7 @@ namespace AdbcDrivers.BigQuery
 
             private IAsyncEnumerator<ReadRowsResponse> CreateEnumerator(long offset, CancellationToken effectiveToken)
             {
-                BigQueryReadClient.ReadRowsStream readRowsStream = this.client.ReadRows(
+                BigQueryReadClient.ReadRowsStream readRowsStream = this.clientMgr.ReadClient.ReadRows(
                     new ReadRowsRequest { ReadStream = this.streamName, Offset = offset });
                 return readRowsStream.GetResponseStream().GetAsyncEnumerator(effectiveToken);
             }

--- a/csharp/src/BigQueryUtils.cs
+++ b/csharp/src/BigQueryUtils.cs
@@ -40,8 +40,18 @@ namespace AdbcDrivers.BigQuery
             {
                 result = true;
             }
+            else if (IsGrpcUnauthenticated(ex))
+            {
+                result = true;
+            }
 
             return result;
+        }
+
+        internal static bool IsGrpcUnauthenticated(Exception ex)
+        {
+            return ContainsException<RpcException>(ex, out RpcException? rpcEx)
+                && rpcEx!.StatusCode == Grpc.Core.StatusCode.Unauthenticated;
         }
 
         internal static string BigQueryAssemblyName = GetAssemblyName(typeof(BigQueryConnection));

--- a/csharp/src/BigQueryUtils.cs
+++ b/csharp/src/BigQueryUtils.cs
@@ -54,6 +54,84 @@ namespace AdbcDrivers.BigQuery
                 && rpcEx!.StatusCode == Grpc.Core.StatusCode.Unauthenticated;
         }
 
+        /// <summary>
+        /// Determines if an exception represents a transient error that should be retried.
+        /// Non-transient errors (invalid SQL, permission issues, etc.) should fail immediately
+        /// to preserve fast feedback and error fidelity.
+        /// </summary>
+        /// <remarks>
+        /// Retryable conditions:
+        /// - HTTP 429 (Too Many Requests)
+        /// - HTTP 5xx (Server errors: 500, 502, 503, 504)
+        /// - gRPC Unavailable, DeadlineExceeded, ResourceExhausted, Aborted, Internal
+        /// - GoogleApiException with "backendError" or "internalError" reason
+        /// - Connection-related errors (connection reset, connection refused)
+        /// </remarks>
+        internal static bool IsRetryableException(Exception ex)
+        {
+            // Check for GoogleApiException (HTTP errors)
+            if (ContainsException<GoogleApiException>(ex, out GoogleApiException? googleEx))
+            {
+                // Retryable HTTP status codes
+                int statusCode = (int)googleEx!.HttpStatusCode;
+                if (statusCode == 429 || // Too Many Requests
+                    statusCode >= 500)   // Server errors (500, 502, 503, 504, etc.)
+                {
+                    return true;
+                }
+
+                // Check for retryable error reasons
+                if (googleEx.Error?.Errors != null && googleEx.Error.Errors.Count > 0)
+                {
+                    string? reason = googleEx.Error.Errors[0].Reason;
+                    if (reason == "backendError" || reason == "internalError" || reason == "rateLimitExceeded")
+                    {
+                        return true;
+                    }
+                }
+
+                // Non-retryable: 400 (Bad Request/Invalid SQL), 401, 403 (Permission), 404, etc.
+                return false;
+            }
+
+            // Check for gRPC exceptions
+            if (ContainsException<RpcException>(ex, out RpcException? rpcEx))
+            {
+                // Retryable gRPC status codes
+                switch (rpcEx!.StatusCode)
+                {
+                    case StatusCode.Unavailable:       // Service unavailable
+                    case StatusCode.DeadlineExceeded:  // Timeout
+                    case StatusCode.ResourceExhausted: // Rate limiting
+                    case StatusCode.Aborted:           // Conflict/retry
+                    case StatusCode.Internal:          // Internal server error
+                        return true;
+                    default:
+                        // Non-retryable: InvalidArgument, PermissionDenied, NotFound, etc.
+                        return false;
+                }
+            }
+
+            // Check for connection-related errors
+            string message = ex.Message?.ToLowerInvariant() ?? string.Empty;
+            if (message.Contains("connection reset") ||
+                message.Contains("connection refused") ||
+                message.Contains("http2: stream closed") ||
+                ex is System.IO.IOException)
+            {
+                return true;
+            }
+
+            // Check inner exceptions
+            if (ex.InnerException != null && ex.InnerException != ex)
+            {
+                return IsRetryableException(ex.InnerException);
+            }
+
+            // Default: not retryable (fail fast for unknown errors)
+            return false;
+        }
+
         internal static string BigQueryAssemblyName = GetAssemblyName(typeof(BigQueryConnection));
 
         internal static string BigQueryAssemblyVersion = GetAssemblyVersion(typeof(BigQueryConnection));

--- a/csharp/src/RetryManager.cs
+++ b/csharp/src/RetryManager.cs
@@ -46,10 +46,11 @@ namespace AdbcDrivers.BigQuery
                 throw new AdbcException("There is no method to retry", AdbcStatusCode.InvalidArgument);
             }
 
-            int retryCount = 0;
+            int attempt = 0;
+            int maxAttempts = maxRetries + 1; // maxRetries=0 means 1 attempt, maxRetries=5 means 6 attempts
             int delay = initialDelayMilliseconds;
 
-            while (retryCount < maxRetries)
+            while (attempt < maxAttempts)
             {
                 try
                 {
@@ -60,21 +61,21 @@ namespace AdbcDrivers.BigQuery
                 {
                     // Note: OperationCanceledException could be thrown from the call,
                     // but we only want to break out when the cancellation was requested from the caller.
-                    activity?.AddException(ex, BigQueryUtils.BuildExceptionTagList(retryCount, ex));
+                    activity?.AddException(ex, BigQueryUtils.BuildExceptionTagList(attempt, ex));
 
-                    retryCount++;
-                    if (retryCount >= maxRetries)
+                    attempt++;
+                    if (attempt >= maxAttempts)
                     {
                         if ((tokenProtectedResource?.UpdateToken != null))
                         {
                             if (tokenProtectedResource?.TokenRequiresUpdate(ex) == true)
                             {
                                 activity?.AddBigQueryTag("update_token.status", "Expired");
-                                throw new AdbcException($"Cannot update access token after {maxRetries} tries. Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.Unauthenticated, ex);
+                                throw new AdbcException($"Cannot update access token after {maxAttempts} attempt(s). Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.Unauthenticated, ex);
                             }
                         }
 
-                        throw new AdbcException($"Cannot execute {action.Method.Name} after {maxRetries} tries. Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.UnknownError, ex);
+                        throw new AdbcException($"Cannot execute {action.Method.Name} after {maxAttempts} attempt(s). Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.UnknownError, ex);
                     }
 
                     if ((tokenProtectedResource?.UpdateToken != null))
@@ -87,11 +88,12 @@ namespace AdbcDrivers.BigQuery
                         }
                     }
 
-                    await Task.Delay(delay);
+                    await Task.Delay(delay, cancellationToken);
                     delay = Math.Min(2 * delay, 5000);
                 }
             }
 
+            // This should be unreachable, but kept as a safety net
             throw new AdbcException($"Could not successfully call {action.Method.Name}", AdbcStatusCode.UnknownError);
         }
     }

--- a/csharp/src/RetryManager.cs
+++ b/csharp/src/RetryManager.cs
@@ -20,11 +20,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-using Apache.Arrow.Adbc;
 using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Apache.Arrow.Adbc;
 
 namespace AdbcDrivers.BigQuery
 {

--- a/csharp/src/RetryManager.cs
+++ b/csharp/src/RetryManager.cs
@@ -30,6 +30,8 @@ namespace AdbcDrivers.BigQuery
 {
     /// <summary>
     /// Class that will retry calling a method with a backoff.
+    /// Only transient errors (server errors, rate limiting, connection issues) are retried.
+    /// Non-transient errors (invalid SQL, permission issues) fail immediately.
     /// </summary>
     internal class RetryManager
     {
@@ -47,6 +49,7 @@ namespace AdbcDrivers.BigQuery
             }
 
             int attempt = 0;
+            int tokenRefreshAttempts = 0;
             int maxAttempts = maxRetries + 1; // maxRetries=0 means 1 attempt, maxRetries=5 means 6 attempts
             int delay = initialDelayMilliseconds;
 
@@ -63,29 +66,48 @@ namespace AdbcDrivers.BigQuery
                     // but we only want to break out when the cancellation was requested from the caller.
                     activity?.AddException(ex, BigQueryUtils.BuildExceptionTagList(attempt, ex));
 
+                    // Check if this is an authentication error that requires token refresh
+                    bool isAuthError = tokenProtectedResource?.TokenRequiresUpdate(ex) == true;
+
+                    // Check if this is a retryable transient error
+                    bool isRetryable = BigQueryUtils.IsRetryableException(ex);
+
+                    // Only retry if it's an auth error (with token refresh) or a transient error
+                    if (!isAuthError && !isRetryable)
+                    {
+                        // Non-retryable error: fail fast to preserve error fidelity
+                        activity?.AddBigQueryTag("retry.skipped", "non_retryable_error");
+                        throw;
+                    }
+
                     attempt++;
                     if (attempt >= maxAttempts)
                     {
-                        if ((tokenProtectedResource?.UpdateToken != null))
-                        {
-                            if (tokenProtectedResource?.TokenRequiresUpdate(ex) == true)
-                            {
-                                activity?.AddBigQueryTag("update_token.status", "Expired");
-                                throw new AdbcException($"Cannot update access token after {maxAttempts} attempt(s). Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.Unauthenticated, ex);
-                            }
-                        }
+                        // Build a clear error message that describes what actually happened
+                        string tokenRefreshInfo = tokenRefreshAttempts > 0
+                            ? $" ({tokenRefreshAttempts} token refresh(es) attempted)"
+                            : string.Empty;
 
-                        throw new AdbcException($"Cannot execute {action.Method.Name} after {maxAttempts} attempt(s). Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.UnknownError, ex);
+                        AdbcStatusCode statusCode = isAuthError
+                            ? AdbcStatusCode.Unauthenticated
+                            : AdbcStatusCode.UnknownError;
+
+                        activity?.AddBigQueryTag("retry.token_refresh_attempts", tokenRefreshAttempts);
+
+                        throw new AdbcException(
+                            $"Operation failed after {maxAttempts} attempt(s){tokenRefreshInfo}. Last exception: {ex.GetType().Name}: {ex.Message}",
+                            statusCode,
+                            ex);
                     }
 
-                    if ((tokenProtectedResource?.UpdateToken != null))
+                    // Attempt token refresh if needed
+                    if (isAuthError && tokenProtectedResource?.UpdateToken != null)
                     {
-                        if (tokenProtectedResource.TokenRequiresUpdate(ex) == true)
-                        {
-                            activity?.AddBigQueryTag("update_token.status", "Required");
-                            await tokenProtectedResource.UpdateToken();
-                            activity?.AddBigQueryTag("update_token.status", "Completed");
-                        }
+                        tokenRefreshAttempts++;
+                        activity?.AddBigQueryTag("update_token.status", "Required");
+                        activity?.AddBigQueryTag("update_token.attempt", tokenRefreshAttempts);
+                        await tokenProtectedResource.UpdateToken();
+                        activity?.AddBigQueryTag("update_token.status", "Completed");
                     }
 
                     await Task.Delay(delay, cancellationToken);

--- a/csharp/test/BigQueryStatementTests.cs
+++ b/csharp/test/BigQueryStatementTests.cs
@@ -31,6 +31,7 @@ using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;
 using Google.Api.Gax.Grpc;
+using Google.Apis.Auth.OAuth2;
 using Google.Cloud.BigQuery.Storage.V1;
 using Grpc.Core;
 using Moq;
@@ -214,18 +215,29 @@ namespace AdbcDrivers.BigQuery.Tests
             string streamName,
             int maxRetryAttempts = 3,
             int retryDelayMs = 100,
-            CancellationToken streamCancellationToken = default)
+            CancellationToken streamCancellationToken = default,
+            Func<Task>? updateToken = null)
         {
             // Use reflection to create ReadRowsStream since it's a private nested class.
-            // Constructor: ReadRowsStream(IActivityTracer, BigQueryReadClient, string, int, int, CancellationToken)
+            // Constructor: ReadRowsStream(IActivityTracer, TokenProtectedReadClientManger, string, int, int, CancellationToken)
             var readRowsStreamType = typeof(BigQueryStatement).GetNestedType("ReadRowsStream", BindingFlags.NonPublic);
             Assert.NotNull(readRowsStreamType);
+
+            var clientMgr = new TokenProtectedReadClientManger(GoogleCredential.FromAccessToken("test-token"));
+            // Replace the read client with the mock
+            typeof(TokenProtectedReadClientManger)
+                .GetField("bigQueryReadClient", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(clientMgr, client);
+            if (updateToken != null)
+            {
+                clientMgr.UpdateToken = updateToken;
+            }
 
             return (IArrowArrayStream)Activator.CreateInstance(
                 readRowsStreamType,
                 BindingFlags.Instance | BindingFlags.Public,
                 null,
-                new object[] { CreateStubTracer(), client, streamName, maxRetryAttempts, retryDelayMs, streamCancellationToken },
+                new object[] { CreateStubTracer(), clientMgr, streamName, maxRetryAttempts, retryDelayMs, streamCancellationToken },
                 null)!;
         }
 
@@ -462,6 +474,157 @@ namespace AdbcDrivers.BigQuery.Tests
             var method = typeof(BigQueryStatement).GetMethod("GetEffectiveQueryResultsTimeout", bindingAttr);
             Assert.NotNull(method);
             return (TimeSpan?)method!.Invoke(statement, null);
+        }
+
+        #endregion
+
+        #region ReadRowsStream Unauthenticated tests
+
+        [Fact]
+        public async Task ReadRowsStream_ThrowsUnauthenticated_ImmediatelyWithoutRetries()
+        {
+            // Arrange - MoveNextAsync throws gRPC Unauthenticated and no UpdateToken is set.
+            // Without a token refresh delegate, the driver should throw immediately.
+            int callCount = 0;
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() =>
+                {
+                    callCount++;
+                    return CreateFailingReadRowsStream(
+                        new RpcException(new Status(StatusCode.Unauthenticated,
+                            "Request had invalid authentication credentials. Expected OAuth 2 access token.")));
+                });
+
+            var stream = CreateReadRowsStreamForTest(mockReadClient.Object, "test-stream", maxRetryAttempts: 5, retryDelayMs: 10);
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stream.ReadNextRecordBatchAsync(CancellationToken.None).AsTask());
+
+            Assert.Equal(AdbcStatusCode.Unauthenticated, ex.Status);
+            Assert.Contains("Authentication failed", ex.Message);
+            Assert.Contains("test-stream", ex.Message);
+            // Should NOT have retried - only 1 call to ReadRows (the initial setup)
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task ReadRowsStream_ThrowsUnauthenticated_PreservesInnerException()
+        {
+            // Arrange - the original RpcException should be preserved as InnerException
+            var rpcException = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() => CreateFailingReadRowsStream(rpcException));
+
+            var stream = CreateReadRowsStreamForTest(mockReadClient.Object, "test-stream", maxRetryAttempts: 3, retryDelayMs: 10);
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stream.ReadNextRecordBatchAsync(CancellationToken.None).AsTask());
+
+            // Assert - inner exception is the original RpcException
+            Assert.IsType<RpcException>(ex.InnerException);
+            Assert.Equal(StatusCode.Unauthenticated, ((RpcException)ex.InnerException).StatusCode);
+        }
+
+        [Fact]
+        public async Task ReadRowsStream_RetriesNonAuthErrors_ThenFailsWithIOError()
+        {
+            // Arrange - gRPC Unavailable errors should still be retried and surface as IOError
+            int callCount = 0;
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() =>
+                {
+                    callCount++;
+                    return CreateFailingReadRowsStream(
+                        new RpcException(new Status(StatusCode.Unavailable, "Stream temporarily unavailable")));
+                });
+
+            var stream = CreateReadRowsStreamForTest(mockReadClient.Object, "test-stream", maxRetryAttempts: 2, retryDelayMs: 10);
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stream.ReadNextRecordBatchAsync(CancellationToken.None).AsTask());
+
+            // Assert - non-auth errors still get IOError status and do retry
+            Assert.Equal(AdbcStatusCode.IOError, ex.Status);
+            Assert.Equal(3, callCount); // 1 initial + 2 retries
+        }
+
+        [Fact]
+        public async Task ReadRowsStream_RefreshesToken_OnUnauthenticated_WhenUpdateTokenIsSet()
+        {
+            // Arrange - First MoveNextAsync throws Unauthenticated, but UpdateToken is set.
+            // After token refresh, the reconnected stream should succeed.
+            int callCount = 0;
+            bool tokenRefreshed = false;
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                    {
+                        // First call: stream opens for lazy init
+                        return CreateFailingReadRowsStream(
+                            new RpcException(new Status(StatusCode.Unauthenticated,
+                                "Request had invalid authentication credentials.")));
+                    }
+                    // After token refresh: return empty stream (no rows)
+                    return CreateEmptyReadRowsStream();
+                });
+
+            var stream = CreateReadRowsStreamForTest(
+                mockReadClient.Object, "test-stream",
+                maxRetryAttempts: 5, retryDelayMs: 10,
+                updateToken: () => { tokenRefreshed = true; return Task.CompletedTask; });
+
+            // Act - ReadNextRecordBatchAsync should refresh the token and reconnect
+            var result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Null(result); // empty stream returns null
+            Assert.True(tokenRefreshed, "UpdateToken should have been called");
+            Assert.Equal(2, callCount); // 1 initial (failed) + 1 after refresh
+        }
+
+        [Fact]
+        public async Task ReadRowsStream_ThrowsUnauthenticated_WhenTokenRefreshAlsoFails()
+        {
+            // Arrange - Unauthenticated error AND UpdateToken throws (e.g., Entra ID token also expired).
+            // Should still throw AdbcException with Unauthenticated status.
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() => CreateFailingReadRowsStream(
+                    new RpcException(new Status(StatusCode.Unauthenticated,
+                        "Request had invalid authentication credentials."))));
+
+            var stream = CreateReadRowsStreamForTest(
+                mockReadClient.Object, "test-stream",
+                maxRetryAttempts: 5, retryDelayMs: 10,
+                updateToken: () => throw new Exception("Entra ID token also expired"));
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stream.ReadNextRecordBatchAsync(CancellationToken.None).AsTask());
+
+            // Assert - still surfaces as Unauthenticated
+            Assert.Equal(AdbcStatusCode.Unauthenticated, ex.Status);
+            Assert.Contains("Authentication failed", ex.Message);
         }
 
         #endregion

--- a/csharp/test/BigQueryStatementTests.cs
+++ b/csharp/test/BigQueryStatementTests.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;

--- a/csharp/test/BigQueryStatementTests.cs
+++ b/csharp/test/BigQueryStatementTests.cs
@@ -626,6 +626,67 @@ namespace AdbcDrivers.BigQuery.Tests
             Assert.Contains("Authentication failed", ex.Message);
         }
 
+
+        [Fact]
+        public async Task ReadRowsStream_TokenRefreshAndGeneralRetries_TrackedSeparately()
+        {
+            // Arrange - Validates that token refresh attempts don't consume general retry budget.
+            // Scenario:
+            // 1. First call: Unauthenticated -> token refresh (tokenRefreshCount=1)
+            // 2. Second call: Unavailable -> general retry (retryCount=1)
+            // 3. Third call: Unauthenticated -> token refresh (tokenRefreshCount=2)
+            // 4. Fourth call: Unavailable -> general retry (retryCount=2, exhausted)
+            // 5. Fifth call: Should fail with IOError (general retries exhausted)
+            // With maxRetries=2, both budgets should be independent.
+            int callCount = 0;
+            int tokenRefreshCount = 0;
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() =>
+                {
+                    callCount++;
+                    // First 2 calls: auth errors (to test token refresh budget)
+                    // Remaining calls: transient errors (to test general retry budget)
+                    if (callCount <= 2)
+                    {
+                        return CreateFailingReadRowsStream(
+                            new RpcException(new Status(StatusCode.Unauthenticated,
+                                "Request had invalid authentication credentials.")));
+                    }
+                    else
+                    {
+                        return CreateFailingReadRowsStream(
+                            new RpcException(new Status(StatusCode.Unavailable,
+                                "Stream temporarily unavailable")));
+                    }
+                });
+
+            var stream = CreateReadRowsStreamForTest(
+                mockReadClient.Object, "test-stream",
+                maxRetryAttempts: 2, retryDelayMs: 10,
+                updateToken: () => { tokenRefreshCount++; return Task.CompletedTask; });
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stream.ReadNextRecordBatchAsync(CancellationToken.None).AsTask());
+
+            // Assert - general retries exhausted (IOError), not auth error
+            // This proves token refreshes didn't consume the general retry budget.
+            Assert.Equal(AdbcStatusCode.IOError, ex.Status);
+            Assert.Contains("2 retries", ex.Message); // maxRetries was 2
+
+            // Should have had multiple token refreshes AND multiple general retries:
+            // Call 1: Unauth -> token refresh 1 -> reconnect
+            // Call 2: Unavailable -> general retry 1 -> reconnect
+            // Call 3: Unauth -> token refresh 2 -> reconnect
+            // Call 4: Unavailable -> general retry 2 -> reconnect
+            // Call 5: Unavailable -> general retries exhausted -> throw IOError
+            Assert.Equal(2, tokenRefreshCount);
+            Assert.Equal(5, callCount); // 1 initial + 2 token refresh reconnects + 2 general retry reconnects
+        }
+
         #endregion
     }
 }

--- a/csharp/test/BigQueryUtilsTests.cs
+++ b/csharp/test/BigQueryUtilsTests.cs
@@ -15,8 +15,8 @@
 */
 
 using System;
-using Google;
 using System.Net;
+using Google;
 using Grpc.Core;
 using Xunit;
 

--- a/csharp/test/BigQueryUtilsTests.cs
+++ b/csharp/test/BigQueryUtilsTests.cs
@@ -143,5 +143,169 @@ namespace AdbcDrivers.BigQuery.Tests
         }
 
         #endregion
+
+        #region IsRetryableException tests
+
+        [Theory]
+        [InlineData(HttpStatusCode.InternalServerError)] // 500
+        [InlineData(HttpStatusCode.BadGateway)]          // 502
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData(HttpStatusCode.GatewayTimeout)]      // 504
+        public void IsRetryableException_ReturnsTrue_ForServerErrors(HttpStatusCode statusCode)
+        {
+            var ex = new GoogleApiException("BigQuery", "Server error")
+            {
+                HttpStatusCode = statusCode
+            };
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForTooManyRequests()
+        {
+            var ex = new GoogleApiException("BigQuery", "Rate limited")
+            {
+                HttpStatusCode = (HttpStatusCode)429 // Too Many Requests
+            };
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.BadRequest)]    // 400 - Invalid SQL
+        [InlineData(HttpStatusCode.Unauthorized)]  // 401 - Auth (handled separately)
+        [InlineData(HttpStatusCode.Forbidden)]     // 403 - Permission denied
+        [InlineData(HttpStatusCode.NotFound)]      // 404 - Resource not found
+        public void IsRetryableException_ReturnsFalse_ForClientErrors(HttpStatusCode statusCode)
+        {
+            var ex = new GoogleApiException("BigQuery", "Client error")
+            {
+                HttpStatusCode = statusCode
+            };
+
+            Assert.False(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Theory]
+        [InlineData(StatusCode.Unavailable)]
+        [InlineData(StatusCode.DeadlineExceeded)]
+        [InlineData(StatusCode.ResourceExhausted)]
+        [InlineData(StatusCode.Aborted)]
+        [InlineData(StatusCode.Internal)]
+        public void IsRetryableException_ReturnsTrue_ForRetryableGrpcStatus(StatusCode statusCode)
+        {
+            var ex = new RpcException(new Status(statusCode, "Transient error"));
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Theory]
+        [InlineData(StatusCode.InvalidArgument)]    // Bad request
+        [InlineData(StatusCode.PermissionDenied)]   // Permission denied
+        [InlineData(StatusCode.NotFound)]           // Resource not found
+        [InlineData(StatusCode.Unauthenticated)]    // Auth (handled separately)
+        [InlineData(StatusCode.FailedPrecondition)] // Invalid state
+        public void IsRetryableException_ReturnsFalse_ForNonRetryableGrpcStatus(StatusCode statusCode)
+        {
+            var ex = new RpcException(new Status(statusCode, "Non-retryable error"));
+
+            Assert.False(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForBackendErrorReason()
+        {
+            var ex = new GoogleApiException("BigQuery", "Backend error")
+            {
+                HttpStatusCode = HttpStatusCode.BadRequest,
+                Error = new Google.Apis.Requests.RequestError
+                {
+                    Errors = new[] { new Google.Apis.Requests.SingleError { Reason = "backendError" } }
+                }
+            };
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForInternalErrorReason()
+        {
+            var ex = new GoogleApiException("BigQuery", "Internal error")
+            {
+                HttpStatusCode = HttpStatusCode.BadRequest,
+                Error = new Google.Apis.Requests.RequestError
+                {
+                    Errors = new[] { new Google.Apis.Requests.SingleError { Reason = "internalError" } }
+                }
+            };
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForRateLimitExceededReason()
+        {
+            var ex = new GoogleApiException("BigQuery", "Rate limit exceeded")
+            {
+                HttpStatusCode = HttpStatusCode.Forbidden,
+                Error = new Google.Apis.Requests.RequestError
+                {
+                    Errors = new[] { new Google.Apis.Requests.SingleError { Reason = "rateLimitExceeded" } }
+                }
+            };
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsFalse_ForInvalidQueryReason()
+        {
+            var ex = new GoogleApiException("BigQuery", "Invalid query")
+            {
+                HttpStatusCode = HttpStatusCode.BadRequest,
+                Error = new Google.Apis.Requests.RequestError
+                {
+                    Errors = new[] { new Google.Apis.Requests.SingleError { Reason = "invalidQuery" } }
+                }
+            };
+
+            Assert.False(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForConnectionResetMessage()
+        {
+            var ex = new Exception("Connection reset by peer");
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForConnectionRefusedMessage()
+        {
+            var ex = new Exception("Connection refused");
+
+            Assert.True(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsTrue_ForNestedRetryableException()
+        {
+            var inner = new RpcException(new Status(StatusCode.Unavailable, "Transient error"));
+            var outer = new Exception("Wrapper", inner);
+
+            Assert.True(BigQueryUtils.IsRetryableException(outer));
+        }
+
+        [Fact]
+        public void IsRetryableException_ReturnsFalse_ForGenericException()
+        {
+            var ex = new Exception("Unknown error");
+
+            Assert.False(BigQueryUtils.IsRetryableException(ex));
+        }
+
+        #endregion
     }
 }

--- a/csharp/test/BigQueryUtilsTests.cs
+++ b/csharp/test/BigQueryUtilsTests.cs
@@ -1,0 +1,147 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using Google;
+using System.Net;
+using Grpc.Core;
+using Xunit;
+
+namespace AdbcDrivers.BigQuery.Tests
+{
+    public class BigQueryUtilsTests
+    {
+        #region IsGrpcUnauthenticated tests
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsTrue_ForRpcExceptionWithUnauthenticatedStatus()
+        {
+            var ex = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+
+            Assert.True(BigQueryUtils.IsGrpcUnauthenticated(ex));
+        }
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsFalse_ForRpcExceptionWithOtherStatus()
+        {
+            var ex = new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
+
+            Assert.False(BigQueryUtils.IsGrpcUnauthenticated(ex));
+        }
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsFalse_ForNonRpcException()
+        {
+            var ex = new InvalidOperationException("Something went wrong");
+
+            Assert.False(BigQueryUtils.IsGrpcUnauthenticated(ex));
+        }
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsTrue_ForNestedRpcException()
+        {
+            var inner = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+            var outer = new InvalidOperationException("Wrapper", inner);
+
+            Assert.True(BigQueryUtils.IsGrpcUnauthenticated(outer));
+        }
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsTrue_ForAggregateExceptionContainingUnauthenticated()
+        {
+            var rpcEx = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+            var aggregate = new AggregateException("Multiple errors", rpcEx);
+
+            Assert.True(BigQueryUtils.IsGrpcUnauthenticated(aggregate));
+        }
+
+        [Fact]
+        public void IsGrpcUnauthenticated_ReturnsFalse_ForRpcExceptionWithPermissionDenied()
+        {
+            // PermissionDenied (gRPC 7) is different from Unauthenticated (gRPC 16)
+            var ex = new RpcException(new Status(StatusCode.PermissionDenied, "Access denied"));
+
+            Assert.False(BigQueryUtils.IsGrpcUnauthenticated(ex));
+        }
+
+        #endregion
+
+        #region TokenRequiresUpdate tests
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsTrue_ForGoogleApiUnauthorized()
+        {
+            var ex = new GoogleApiException("BigQuery", "Unauthorized")
+            {
+                HttpStatusCode = HttpStatusCode.Unauthorized
+            };
+
+            Assert.True(BigQueryUtils.TokenRequiresUpdate(ex));
+        }
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsTrue_ForGrpcUnauthenticated()
+        {
+            var ex = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+
+            Assert.True(BigQueryUtils.TokenRequiresUpdate(ex));
+        }
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsFalse_ForGrpcUnavailable()
+        {
+            var ex = new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
+
+            Assert.False(BigQueryUtils.TokenRequiresUpdate(ex));
+        }
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsFalse_ForGenericException()
+        {
+            var ex = new Exception("Something failed");
+
+            Assert.False(BigQueryUtils.TokenRequiresUpdate(ex));
+        }
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsTrue_ForNestedGrpcUnauthenticated()
+        {
+            var inner = new RpcException(new Status(StatusCode.Unauthenticated,
+                "Request had invalid authentication credentials."));
+            var outer = new Exception("Wrapper", inner);
+
+            Assert.True(BigQueryUtils.TokenRequiresUpdate(outer));
+        }
+
+        [Fact]
+        public void TokenRequiresUpdate_ReturnsFalse_ForGoogleApiForbidden()
+        {
+            // HTTP 403 Forbidden is not the same as 401 Unauthorized
+            var ex = new GoogleApiException("BigQuery", "Forbidden")
+            {
+                HttpStatusCode = HttpStatusCode.Forbidden
+            };
+
+            Assert.False(BigQueryUtils.TokenRequiresUpdate(ex));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## What's Changed

- Adds retries for the initial CreateQueryJobAsync call (errors found in logs)
- Adds a check for IsGrpcUnauthenticated and attempts to re-exchange the user token for the Google token