### PR TITLE
fix(csharp): add additional reader cancellation token

### DIFF
--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -772,9 +772,11 @@ namespace AdbcDrivers.BigQuery
 
         public override void Cancel()
         {
-            this.TraceActivity(_ =>
+            this.TraceActivity(activity =>
             {
-                this.cancellationRegistry.CancelAll();
+                CancellationOrigin origin = new CancellationOrigin("BigQueryStatement.Cancel");
+                activity?.AddEvent("statement_cancel_requested", origin.ToTags("cancel.origin").ToList());
+                this.cancellationRegistry.CancelAll("BigQueryStatement.Cancel");
             }, ClassName + "." + nameof(Cancel));
         }
 
@@ -1126,6 +1128,11 @@ namespace AdbcDrivers.BigQuery
             {
                 // Note: OperationCanceledException could be thrown from the call,
                 // but we only want to handle when the cancellation was requested from the context.
+                CancellationOrigin? origin = context.CancelOrigin;
+                if (origin != null)
+                {
+                    activity?.AddEvent("job_cancellation_origin", origin.ToTags("context.cancel").ToList());
+                }
                 activity?.AddException(cancelledEx!);
                 try
                 {
@@ -1191,10 +1198,45 @@ namespace AdbcDrivers.BigQuery
             return tags;
         }
 
+        /// <summary>
+        /// Diagnostic snapshot describing where and why a cancellation was initiated.
+        /// Captured the first time a CancellationContext (or the MultiArrowReader's linked CTS)
+        /// is cancelled, so later observers can determine the root cause of a
+        /// "task was canceled" error.
+        /// </summary>
+        private sealed class CancellationOrigin
+        {
+            public CancellationOrigin(string reason, string? exceptionInfo = null)
+            {
+                Reason = reason;
+                TimestampUtc = DateTimeOffset.UtcNow;
+                ThreadId = Environment.CurrentManagedThreadId;
+                StackTrace = new StackTrace(skipFrames: 1, fNeedFileInfo: false).ToString();
+                ExceptionInfo = exceptionInfo;
+            }
+
+            public string Reason { get; }
+            public DateTimeOffset TimestampUtc { get; }
+            public int ThreadId { get; }
+            public string StackTrace { get; }
+            public string? ExceptionInfo { get; }
+
+            public IEnumerable<KeyValuePair<string, object?>> ToTags(string prefix)
+            {
+                yield return new(prefix + ".reason", Reason);
+                yield return new(prefix + ".timestamp_utc", TimestampUtc.ToString("O"));
+                yield return new(prefix + ".thread_id", ThreadId);
+                yield return new(prefix + ".stack_trace", StackTrace);
+                if (ExceptionInfo != null)
+                    yield return new(prefix + ".exception", ExceptionInfo);
+            }
+        }
+
         private class CancellationContext : IDisposable
         {
             private readonly CancellationRegistry cancellationRegistry;
             private readonly CancellationTokenSource cancellationTokenSource;
+            private CancellationOrigin? cancelOrigin;
             private bool disposed;
 
             public CancellationContext(CancellationRegistry cancellationRegistry)
@@ -1206,8 +1248,18 @@ namespace AdbcDrivers.BigQuery
 
             public CancellationToken CancellationToken => cancellationTokenSource.Token;
 
-            public void Cancel()
+            /// <summary>
+            /// The first-recorded reason this context was cancelled, or null if it has not
+            /// been cancelled. First-cancel-wins via Interlocked.CompareExchange so the
+            /// originating cause is preserved even if Cancel() is called repeatedly.
+            /// </summary>
+            public CancellationOrigin? CancelOrigin => Volatile.Read(ref cancelOrigin);
+
+            public void Cancel() => Cancel("unspecified");
+
+            public void Cancel(string reason)
             {
+                Interlocked.CompareExchange(ref cancelOrigin, new CancellationOrigin(reason), null);
                 cancellationTokenSource.Cancel();
             }
 
@@ -1253,13 +1305,15 @@ namespace AdbcDrivers.BigQuery
                 return contexts.TryRemove(context, out _);
             }
 
-            public void CancelAll()
+            public void CancelAll() => CancelAll("unspecified");
+
+            public void CancelAll(string reason)
             {
                 if (disposed) throw new ObjectDisposedException(nameof(CancellationRegistry));
 
                 foreach (CancellationContext context in contexts.Keys)
                 {
-                    context.Cancel();
+                    context.Cancel(reason);
                 }
             }
 
@@ -1290,6 +1344,7 @@ namespace AdbcDrivers.BigQuery
             long memoryAtStart;
             long peakMemory;
             long totalBatchesRead;
+            CancellationOrigin? linkedCancelOrigin;
             bool disposed;
 
             public MultiArrowReader(BigQueryStatement statement, Schema schema, IEnumerable<IArrowReader> readers, CancellationContext cancellationContext, int maxConcurrency = 0) : base(statement)
@@ -1373,11 +1428,53 @@ namespace AdbcDrivers.BigQuery
                     // Graceful shutdown: either user cancellation or another producer failed.
                     // Swallow so Task.WhenAll only surfaces the root cause.
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // A real failure in this producer — cancel siblings and propagate.
-                    this.linkedCts.Cancel();
+                    CancelLinked("producer_failure", ex);
                     throw;
+                }
+            }
+
+            /// <summary>
+            /// Cancels the reader's linked CancellationTokenSource and records the origin
+            /// (reason + stack trace + optional inner exception) on first call, so any
+            /// subsequent OperationCanceledException observed by readers can be traced
+            /// back to its true cause.
+            /// </summary>
+            private void CancelLinked(string reason, Exception? cause = null)
+            {
+                CancellationOrigin origin = new CancellationOrigin(reason, cause?.ToString());
+                Interlocked.CompareExchange(ref this.linkedCancelOrigin, origin, null);
+                try
+                {
+                    this.linkedCts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The linked CTS may already be disposed if Dispose ran concurrently.
+                }
+            }
+
+            /// <summary>
+            /// Annotates the supplied activity with whatever cancellation-origin diagnostics
+            /// are available, including both the reader's linked CTS origin and the outer
+            /// statement-level CancellationContext origin (if any).
+            /// </summary>
+            private void AddCancellationDiagnostics(Activity? activity)
+            {
+                if (activity == null) return;
+
+                CancellationOrigin? linkedOrigin = Volatile.Read(ref this.linkedCancelOrigin);
+                if (linkedOrigin != null)
+                {
+                    activity.AddEvent("reader_linked_cts_canceled", linkedOrigin.ToTags("linked_cts").ToList());
+                }
+
+                CancellationOrigin? contextOrigin = this.cancellationContext.CancelOrigin;
+                if (contextOrigin != null)
+                {
+                    activity.AddEvent("reader_context_canceled", contextOrigin.ToTags("reader_context").ToList());
                 }
             }
 
@@ -1386,29 +1483,42 @@ namespace AdbcDrivers.BigQuery
                 return await this.TraceActivityAsync(async activity =>
                 {
                     // Register the caller's token for this call; the linked CTS
-                    // already includes the cancellationContext token.
+                    // already includes the cancellationContext token. Funnel the
+                    // cancellation through CancelLinked so the origin (reason +
+                    // stack trace) is captured for later diagnostics.
                     using var callerReg = cancellationToken.CanBeCanceled
-                        ? cancellationToken.Register(() => this.linkedCts.Cancel())
+                        ? cancellationToken.Register(() => CancelLinked("caller_token"))
                         : default;
 
                     EnsureProducersStarted();
 
                     CancellationToken ct = this.linkedCts.Token;
 
-                    if (await this.channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+                    try
                     {
-                        if (this.channel.Reader.TryRead(out RecordBatch? batch))
+                        if (await this.channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
                         {
-                            Interlocked.Increment(ref this.totalBatchesRead);
-                            if (activity != null)
+                            if (this.channel.Reader.TryRead(out RecordBatch? batch))
                             {
-                                long currentMemory = GC.GetTotalMemory(false);
-                                InterlockedMax(ref this.peakMemory, currentMemory);
-                                activity.AddBigQueryTag("memory.current_bytes", currentMemory);
+                                Interlocked.Increment(ref this.totalBatchesRead);
+                                if (activity != null)
+                                {
+                                    long currentMemory = GC.GetTotalMemory(false);
+                                    InterlockedMax(ref this.peakMemory, currentMemory);
+                                    activity.AddBigQueryTag("memory.current_bytes", currentMemory);
+                                }
+                                activity?.AddTag(SemanticConventions.Db.Response.ReturnedRows, batch.Length);
+                                return batch;
                             }
-                            activity?.AddTag(SemanticConventions.Db.Response.ReturnedRows, batch.Length);
-                            return batch;
                         }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Surface why the reader was cancelled before the exception
+                        // bubbles up, so consumers tracing "a task was canceled" can
+                        // see the originating reason and stack.
+                        AddCancellationDiagnostics(activity);
+                        throw;
                     }
 
                     activity?.AddTag(SemanticConventions.Db.Response.ReturnedRows, 0);
@@ -1426,7 +1536,7 @@ namespace AdbcDrivers.BigQuery
                 {
                     if (!this.disposed)
                     {
-                        this.linkedCts.Cancel();
+                        CancelLinked("reader_dispose");
                         try { this.producerTask?.GetAwaiter().GetResult(); } catch { /* producers reported errors via channel */ }
                         foreach (var reader in this.readerList)
                         {

--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -279,19 +279,29 @@ namespace AdbcDrivers.BigQuery
 
                 long totalRows = results.TotalRows == null ? -1L : (long)results.TotalRows.Value;
 
+                // Create the reader-scoped cancellation context up front so that the same
+                // token can be embedded in every ReadRowsStream. The job-scoped
+                // cancellationContext is disposed when this method returns (via the `using`
+                // above), so any token captured from it would already be unusable by the
+                // time the consumer starts pulling batches. The reader-scoped context's
+                // lifetime is owned by the MultiArrowReader returned below.
+                CancellationContext readerCancellationContext = new CancellationContext(cancellationRegistry);
+
                 Task<IEnumerable<IArrowReader>> getArrowReadersFunc()
                 {
                     return ExecuteCancellableJobAsync(cancellationContext, activity, (context, jobActivity) =>
                     {
                         // Cancelling this step may leave the server with unread streams.
                         jobActivity?.AddBigQueryTag("job.id", context.Job?.Reference.JobId);
-                        return GetArrowReaders(clientMgr, table, results.TableReference.ProjectId, maxStreamCount, jobActivity, context.CancellationToken);
+                        // Pass the reader-scoped token so each ReadRowsStream survives
+                        // beyond the disposal of the job-scoped cancellationContext.
+                        return GetArrowReaders(clientMgr, table, results.TableReference.ProjectId, maxStreamCount, jobActivity, readerCancellationContext.CancellationToken);
                     }, ClassName + "." + nameof(ExecuteQueryInternalAsync) + "." + nameof(GetArrowReaders));
                 }
                 IEnumerable<IArrowReader> readers = await ExecuteWithRetriesAsync(getArrowReadersFunc, activity, cancellationContext.CancellationToken).ConfigureAwait(false);
 
                 // Note: MultiArrowReader must dispose the cancellationContext.
-                IArrowArrayStream stream = new MultiArrowReader(this, TranslateSchema(results.Schema), readers, new CancellationContext(cancellationRegistry), maxStreamCount);
+                IArrowArrayStream stream = new MultiArrowReader(this, TranslateSchema(results.Schema), readers, readerCancellationContext, maxStreamCount);
                 activity?.AddTag(SemanticConventions.Db.Response.ReturnedRows, totalRows);
                 return new QueryResult(totalRows, stream);
             }, ClassName + "." + nameof(ExecuteQueryInternalAsync));

--- a/csharp/src/BigQueryStatement.cs
+++ b/csharp/src/BigQueryStatement.cs
@@ -776,7 +776,7 @@ namespace AdbcDrivers.BigQuery
             {
                 CancellationOrigin origin = new CancellationOrigin("BigQueryStatement.Cancel");
                 activity?.AddEvent("statement_cancel_requested", origin.ToTags("cancel.origin").ToList());
-                this.cancellationRegistry.CancelAll("BigQueryStatement.Cancel");
+                this.cancellationRegistry.CancelAll(origin);
             }, ClassName + "." + nameof(Cancel));
         }
 
@@ -1204,7 +1204,7 @@ namespace AdbcDrivers.BigQuery
         /// is cancelled, so later observers can determine the root cause of a
         /// "task was canceled" error.
         /// </summary>
-        private sealed class CancellationOrigin
+        internal sealed class CancellationOrigin
         {
             public CancellationOrigin(string reason, string? exceptionInfo = null)
             {
@@ -1232,7 +1232,7 @@ namespace AdbcDrivers.BigQuery
             }
         }
 
-        private class CancellationContext : IDisposable
+        internal class CancellationContext : IDisposable
         {
             private readonly CancellationRegistry cancellationRegistry;
             private readonly CancellationTokenSource cancellationTokenSource;
@@ -1255,11 +1255,14 @@ namespace AdbcDrivers.BigQuery
             /// </summary>
             public CancellationOrigin? CancelOrigin => Volatile.Read(ref cancelOrigin);
 
-            public void Cancel() => Cancel("unspecified");
+            public void Cancel() => Cancel(new CancellationOrigin("unspecified"));
 
-            public void Cancel(string reason)
+            public void Cancel(string reason) => Cancel(new CancellationOrigin(reason));
+
+            public void Cancel(CancellationOrigin origin)
             {
-                Interlocked.CompareExchange(ref cancelOrigin, new CancellationOrigin(reason), null);
+                if (origin == null) throw new ArgumentNullException(nameof(origin));
+                Interlocked.CompareExchange(ref cancelOrigin, origin, null);
                 cancellationTokenSource.Cancel();
             }
 
@@ -1274,7 +1277,7 @@ namespace AdbcDrivers.BigQuery
             }
         }
 
-        private class JobCancellationContext : CancellationContext
+        internal class JobCancellationContext : CancellationContext
         {
             public JobCancellationContext(CancellationRegistry cancellationRegistry, BigQueryJob? job = default)
                 : base(cancellationRegistry)
@@ -1285,7 +1288,7 @@ namespace AdbcDrivers.BigQuery
             public BigQueryJob? Job { get; set; }
         }
 
-        private sealed class CancellationRegistry : IDisposable
+        internal sealed class CancellationRegistry : IDisposable
         {
             private readonly ConcurrentDictionary<CancellationContext, byte> contexts = new();
             private bool disposed;
@@ -1305,15 +1308,18 @@ namespace AdbcDrivers.BigQuery
                 return contexts.TryRemove(context, out _);
             }
 
-            public void CancelAll() => CancelAll("unspecified");
+            public void CancelAll() => CancelAll(new CancellationOrigin("unspecified"));
 
-            public void CancelAll(string reason)
+            public void CancelAll(string reason) => CancelAll(new CancellationOrigin(reason));
+
+            public void CancelAll(CancellationOrigin origin)
             {
+                if (origin == null) throw new ArgumentNullException(nameof(origin));
                 if (disposed) throw new ObjectDisposedException(nameof(CancellationRegistry));
 
                 foreach (CancellationContext context in contexts.Keys)
                 {
-                    context.Cancel(reason);
+                    context.Cancel(origin);
                 }
             }
 

--- a/csharp/test/AdbcDrivers.BigQuery.Tests.csproj
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
     <ItemGroup>
      <PackageReference Include="Azure.Identity" Version="1.17.1" />
-       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
        <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
        <PackageReference Include="xunit" Version="2.9.3" />
        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/csharp/test/BigQueryStatementTests.cs
+++ b/csharp/test/BigQueryStatementTests.cs
@@ -773,66 +773,23 @@ namespace AdbcDrivers.BigQuery.Tests
             Assert.True(readerToken.IsCancellationRequested);
         }
 
-        #region Reflection helpers for CancellationRegistry/Context
+        #region CancellationRegistry/Context helpers
 
-        private static readonly Type s_registryType =
-            typeof(BigQueryStatement).GetNestedType("CancellationRegistry", BindingFlags.NonPublic)!;
 
-        private static readonly Type s_contextType =
-            typeof(BigQueryStatement).GetNestedType("CancellationContext", BindingFlags.NonPublic)!;
 
-        private static readonly Type s_jobContextType =
-            typeof(BigQueryStatement).GetNestedType("JobCancellationContext", BindingFlags.NonPublic)!;
+        private static BigQueryStatement.CancellationRegistry CreateRegistry() => new();
 
-        private static IDisposable CreateRegistry()
-        {
-            object instance = Activator.CreateInstance(
-                s_registryType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                Array.Empty<object>(),
-                null)!;
-            return (IDisposable)instance;
-        }
+        private static BigQueryStatement.CancellationContext CreateCancellationContext(BigQueryStatement.CancellationRegistry registry) =>
+            new(registry);
 
-        private static IDisposable CreateCancellationContext(IDisposable registry)
-        {
-            object instance = Activator.CreateInstance(
-                s_contextType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                new object[] { registry },
-                null)!;
-            return (IDisposable)instance;
-        }
+        private static BigQueryStatement.JobCancellationContext CreateJobContext(BigQueryStatement.CancellationRegistry registry) =>
+            new(registry);
 
-        private static IDisposable CreateJobContext(IDisposable registry)
-        {
-            object instance = Activator.CreateInstance(
-                s_jobContextType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                new object?[] { registry, null },
-                null)!;
-            return (IDisposable)instance;
-        }
+        private static CancellationToken GetToken(BigQueryStatement.CancellationContext context) => context.CancellationToken;
 
-        private static CancellationToken GetToken(IDisposable context)
-        {
-            PropertyInfo prop = s_contextType.GetProperty("CancellationToken", BindingFlags.Instance | BindingFlags.Public)!;
-            return (CancellationToken)prop.GetValue(context)!;
-        }
+        private static void DisposeContext(BigQueryStatement.CancellationContext context) => context.Dispose();
 
-        private static void DisposeContext(IDisposable context)
-        {
-            context.Dispose();
-        }
-
-        private static void InvokeCancelAll(IDisposable registry)
-        {
-            MethodInfo method = s_registryType.GetMethod("CancelAll", BindingFlags.Instance | BindingFlags.Public)!;
-            method.Invoke(registry, null);
-        }
+        private static void InvokeCancelAll(BigQueryStatement.CancellationRegistry registry) => registry.CancelAll();
 
         #endregion
 

--- a/csharp/test/BigQueryStatementTests.cs
+++ b/csharp/test/BigQueryStatementTests.cs
@@ -688,5 +688,154 @@ namespace AdbcDrivers.BigQuery.Tests
         }
 
         #endregion
+
+        #region CancellationLifetime tests
+
+        /// <summary>
+        /// Validates the post-fix invariant: a <c>ReadRowsStream</c> built with
+        /// a token from the reader-scoped <c>CancellationContext</c> remains
+        /// usable after the unrelated job-scoped <c>JobCancellationContext</c>
+        /// is disposed (which is what happens at the end of
+        /// <c>ExecuteQueryInternalAsync</c>'s <c>using</c> block).
+        /// </summary>
+        [Fact]
+        public async Task ReadRowsStream_StaysUsable_AfterJobCancellationContextDisposed()
+        {
+            using var registry = CreateRegistry();
+            using var jobContext = CreateJobContext(registry);
+            using var readerContext = CreateCancellationContext(registry);
+
+            CancellationToken jobToken = GetToken(jobContext);
+            CancellationToken readerToken = GetToken(readerContext);
+
+            Assert.False(jobToken.IsCancellationRequested);
+            Assert.False(readerToken.IsCancellationRequested);
+
+            // Mock read client that returns an empty stream so MoveNext returns false.
+            var mockReadClient = new Mock<BigQueryReadClient>(MockBehavior.Strict);
+            mockReadClient
+                .Setup(c => c.ReadRows(It.IsAny<ReadRowsRequest>(), null))
+                .Returns(() => CreateEmptyReadRowsStream());
+
+            // Build the stream using the *reader-scoped* token (the fix).
+            IArrowArrayStream stream = CreateReadRowsStreamForTest(
+                mockReadClient.Object, "test-stream", streamCancellationToken: readerToken);
+
+            // Simulate ExecuteQueryInternalAsync's `using` block exiting:
+            // the job context is disposed without ever being canceled.
+            DisposeContext(jobContext);
+
+            // The reader-scoped token should be unaffected, so the stream
+            // should still be readable. Empty stream returns null.
+            Assert.False(readerToken.IsCancellationRequested);
+            Apache.Arrow.RecordBatch? batch = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+            Assert.Null(batch);
+        }
+
+        /// <summary>
+        /// Disposing one <c>CancellationContext</c> must not cancel a sibling
+        /// context registered on the same <c>CancellationRegistry</c>.
+        /// </summary>
+        [Fact]
+        public void DisposingJobContext_DoesNotAffectSiblingContextToken()
+        {
+            using var registry = CreateRegistry();
+            using var jobContext = CreateJobContext(registry);
+            using var readerContext = CreateCancellationContext(registry);
+
+            CancellationToken readerToken = GetToken(readerContext);
+            Assert.False(readerToken.IsCancellationRequested);
+
+            DisposeContext(jobContext);
+
+            Assert.False(readerToken.IsCancellationRequested);
+            Assert.True(readerToken.CanBeCanceled);
+        }
+
+        /// <summary>
+        /// <c>BigQueryStatement.Cancel()</c> must still cancel the
+        /// reader-scoped context, because the fix keeps it registered with the
+        /// statement's <c>CancellationRegistry</c>.
+        /// </summary>
+        [Fact]
+        public void RegistryCancelAll_CancelsReaderScopedContext()
+        {
+            using var registry = CreateRegistry();
+            using var jobContext = CreateJobContext(registry);
+            using var readerContext = CreateCancellationContext(registry);
+
+            CancellationToken readerToken = GetToken(readerContext);
+            CancellationToken jobToken = GetToken(jobContext);
+
+            InvokeCancelAll(registry);
+
+            Assert.True(jobToken.IsCancellationRequested);
+            Assert.True(readerToken.IsCancellationRequested);
+        }
+
+        #region Reflection helpers for CancellationRegistry/Context
+
+        private static readonly Type s_registryType =
+            typeof(BigQueryStatement).GetNestedType("CancellationRegistry", BindingFlags.NonPublic)!;
+
+        private static readonly Type s_contextType =
+            typeof(BigQueryStatement).GetNestedType("CancellationContext", BindingFlags.NonPublic)!;
+
+        private static readonly Type s_jobContextType =
+            typeof(BigQueryStatement).GetNestedType("JobCancellationContext", BindingFlags.NonPublic)!;
+
+        private static IDisposable CreateRegistry()
+        {
+            object instance = Activator.CreateInstance(
+                s_registryType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                Array.Empty<object>(),
+                null)!;
+            return (IDisposable)instance;
+        }
+
+        private static IDisposable CreateCancellationContext(IDisposable registry)
+        {
+            object instance = Activator.CreateInstance(
+                s_contextType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object[] { registry },
+                null)!;
+            return (IDisposable)instance;
+        }
+
+        private static IDisposable CreateJobContext(IDisposable registry)
+        {
+            object instance = Activator.CreateInstance(
+                s_jobContextType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object?[] { registry, null },
+                null)!;
+            return (IDisposable)instance;
+        }
+
+        private static CancellationToken GetToken(IDisposable context)
+        {
+            PropertyInfo prop = s_contextType.GetProperty("CancellationToken", BindingFlags.Instance | BindingFlags.Public)!;
+            return (CancellationToken)prop.GetValue(context)!;
+        }
+
+        private static void DisposeContext(IDisposable context)
+        {
+            context.Dispose();
+        }
+
+        private static void InvokeCancelAll(IDisposable registry)
+        {
+            MethodInfo method = s_registryType.GetMethod("CancelAll", BindingFlags.Instance | BindingFlags.Public)!;
+            method.Invoke(registry, null);
+        }
+
+        #endregion
+
+        #endregion
     }
 }


### PR DESCRIPTION
## What's Changed

- Adds additional readerCancellationContext for read operations to prevent "task was canceled" error