### PR TITLE
feat(csharp): add in-process BigQuery test fixture

### DIFF
--- a/.github/workflows/csharp_test.yaml
+++ b/.github/workflows/csharp_test.yaml
@@ -84,4 +84,4 @@ jobs:
           dotnet test \
             --no-build \
             -c Release \
-            --filter "FullyQualifiedName~BigQueryUtilsTests|FullyQualifiedName~BigQueryConnectionTests|FullyQualifiedName~BigQueryStatementTests"
+            --filter "FullyQualifiedName~BigQueryUtilsTests|FullyQualifiedName~BigQueryConnectionTests|FullyQualifiedName~BigQueryStatementTests|Category=MockServer"

--- a/.rat-apache
+++ b/.rat-apache
@@ -15,6 +15,7 @@
 .github/workflows/dev_issues.yaml
 csharp/.gitignore
 csharp/Directory.Build.props
+csharp/Directory.Packages.props
 csharp/src/AdbcDrivers.BigQuery/ActivityExtensions.cs
 csharp/src/AdbcDrivers.BigQuery/AssemblyInfo.cs
 csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs

--- a/csharp/AdbcDrivers.BigQuery.sln
+++ b/csharp/AdbcDrivers.BigQuery.sln
@@ -1,6 +1,7 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33403.182
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11801.241 oobstable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdbcDrivers.BigQuery", "src\AdbcDrivers.BigQuery\AdbcDrivers.BigQuery.csproj", "{A748041C-EF9A-4E88-B6FB-9F2D6CB79170}"
 EndProject
@@ -10,11 +11,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc", "arrow-
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Telemetry.Traces.Listeners", "arrow-adbc\csharp\src\Telemetry\Traces\Listeners\Apache.Arrow.Adbc.Telemetry.Traces.Listeners.csproj", "{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Tests", "arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj", "{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Testing", "arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj", "{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Client", "arrow-adbc\csharp\src\Client\Apache.Arrow.Adbc.Client.csproj", "{80163E19-0794-37AE-1FA0-FFFA6A2DEC62}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdbcDrivers.BigQuery.MockServer", "test\AdbcDrivers.BigQuery.MockServer\AdbcDrivers.BigQuery.MockServer.csproj", "{472BC1CA-C429-41CF-98EB-43BE2D5360D5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,6 +49,10 @@ Global
 		{80163E19-0794-37AE-1FA0-FFFA6A2DEC62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{80163E19-0794-37AE-1FA0-FFFA6A2DEC62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80163E19-0794-37AE-1FA0-FFFA6A2DEC62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{472BC1CA-C429-41CF-98EB-43BE2D5360D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{472BC1CA-C429-41CF-98EB-43BE2D5360D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{472BC1CA-C429-41CF-98EB-43BE2D5360D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{472BC1CA-C429-41CF-98EB-43BE2D5360D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/AdbcDrivers.BigQuery.sln
+++ b/csharp/AdbcDrivers.BigQuery.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.5.11801.241 oobstable
+VisualStudioVersion = 18.5.11801.241
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdbcDrivers.BigQuery", "src\AdbcDrivers.BigQuery\AdbcDrivers.BigQuery.csproj", "{A748041C-EF9A-4E88-B6FB-9F2D6CB79170}"
 EndProject

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -50,7 +50,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -1,3 +1,27 @@
+<!--
+  Copyright (c) 2025 ADBC Drivers Contributors
+
+  This file has been modified from its original version, which is
+  under the Apache License:
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Apache.Arrow" Version="22.1.0" />
+    <PackageVersion Include="Apache.Arrow.Adbc.Drivers.BigQuery" Version="0.0.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Google.Cloud.BigQuery.Storage.V1" Version="3.17.0" />
+    <PackageVersion Include="Google.Cloud.BigQuery.V2" Version="3.11.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.9" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
+  </ItemGroup>
+</Project>

--- a/csharp/src/AdbcDrivers.BigQuery/AdbcDrivers.BigQuery.csproj
+++ b/csharp/src/AdbcDrivers.BigQuery/AdbcDrivers.BigQuery.csproj
@@ -5,16 +5,16 @@
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.3" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
-		<PackageReference Include="Google.Cloud.BigQuery.Storage.V1" Version="3.17.0" />
-		<PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.11.0" />
+		<PackageReference Include="System.Net.Http.WinHttpHandler" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
+		<PackageReference Include="Google.Cloud.BigQuery.Storage.V1" />
+		<PackageReference Include="Google.Cloud.BigQuery.V2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj" />
 		<ProjectReference Include="..\..\arrow-adbc\csharp\src\Telemetry\Traces\Listeners\Apache.Arrow.Adbc.Telemetry.Traces.Listeners.csproj" />
 	</ItemGroup>
 	<ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net6.0'))">
-		<PackageReference Include="System.Text.Json" Version="9.0.9" />
+		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="readme.md">

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -155,6 +155,12 @@ namespace AdbcDrivers.BigQuery
             {
                 throw new ArgumentException($"The value '{sClientTimeout}' for parameter '{BigQueryParameters.ClientTimeout}' is not a valid positive integer.");
             }
+
+            if (this.properties.TryGetValue(BigQueryParameters.TestStorageEndpoint, out string? storageEndpoint) &&
+                !string.IsNullOrEmpty(storageEndpoint))
+            {
+                TestStorageEndpoint = storageEndpoint;
+            }
         }
 
         /// <summary>
@@ -198,6 +204,8 @@ namespace AdbcDrivers.BigQuery
         internal TimeSpan? ClientTimeout { get; private set; }
 
         internal bool IncludePublicProjectIds { get; private set; } = false;
+
+        internal string? TestStorageEndpoint { get; private set; }
 
         public override string AssemblyVersion => BigQueryUtils.BigQueryAssemblyVersion;
 
@@ -388,6 +396,12 @@ namespace AdbcDrivers.BigQuery
 
                 bigQueryClientBuilder.ProjectId = !string.IsNullOrEmpty(billingProjectId) ? billingProjectId : projectId;
 
+                if (this.properties.TryGetValue(BigQueryParameters.TestRestEndpoint, out string? testRestEndpoint) &&
+                    !string.IsNullOrEmpty(testRestEndpoint))
+                {
+                    bigQueryClientBuilder.BaseUri = $"http://{testRestEndpoint}/bigquery/v2/";
+                }
+
                 if (!string.IsNullOrEmpty(DefaultClientLocation))
                 {
                     // If the user selects a public dataset (from a multi-region) but sets this
@@ -443,9 +457,10 @@ namespace AdbcDrivers.BigQuery
 
                     if (!authenticationType.Equals(BigQueryConstants.UserAuthenticationType, StringComparison.OrdinalIgnoreCase) &&
                         !authenticationType.Equals(BigQueryConstants.ServiceAccountAuthenticationType, StringComparison.OrdinalIgnoreCase) &&
-                        !authenticationType.Equals(BigQueryConstants.EntraIdAuthenticationType, StringComparison.OrdinalIgnoreCase))
+                        !authenticationType.Equals(BigQueryConstants.EntraIdAuthenticationType, StringComparison.OrdinalIgnoreCase) &&
+                        !authenticationType.Equals(BigQueryConstants.MockAuthenticationType, StringComparison.OrdinalIgnoreCase))
                     {
-                        throw new ArgumentException($"The {BigQueryParameters.AuthenticationType} parameter can only be `{BigQueryConstants.UserAuthenticationType}`, `{BigQueryConstants.ServiceAccountAuthenticationType}` or `{BigQueryConstants.EntraIdAuthenticationType}`");
+                        throw new ArgumentException($"The {BigQueryParameters.AuthenticationType} parameter can only be `{BigQueryConstants.UserAuthenticationType}`, `{BigQueryConstants.ServiceAccountAuthenticationType}`, `{BigQueryConstants.EntraIdAuthenticationType}` or `{BigQueryConstants.MockAuthenticationType}`");
                     }
                     else
                     {
@@ -484,6 +499,10 @@ namespace AdbcDrivers.BigQuery
                         throw new ArgumentException($"The {BigQueryParameters.JsonCredential} parameter is not present");
 
                     Credential = ApplyScopes(GoogleCredential.FromJson(json));
+                }
+                else if (!string.IsNullOrEmpty(authenticationType) && authenticationType.Equals(BigQueryConstants.MockAuthenticationType, StringComparison.OrdinalIgnoreCase))
+                {
+                    Credential = ApplyScopes(GoogleCredential.FromAccessToken("mock-token"));
                 }
                 else
                 {

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryParameters.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryParameters.cs
@@ -63,6 +63,18 @@ namespace AdbcDrivers.BigQuery
         public const string IsMetadataCommand = "adbc.bigquery.statement.is_metadata_command";
 
         /// <summary>
+        /// Overrides the BigQuery REST API endpoint for testing (e.g. "localhost:1234").
+        /// Connects over plain HTTP without TLS. Not for production use.
+        /// </summary>
+        public const string TestRestEndpoint = "adbc.bigquery.test.rest_endpoint";
+
+        /// <summary>
+        /// Overrides the BigQuery Storage gRPC API endpoint for testing (e.g. "localhost:1235").
+        /// Connects over plain HTTP/2 without TLS. Not for production use.
+        /// </summary>
+        public const string TestStorageEndpoint = "adbc.bigquery.test.storage_endpoint";
+
+        /// <summary>
         /// Indicates whether the driver should create the dataset specified in the
         /// <see cref="LargeResultsDataset"/> parameter if it does not already exist.
         /// </summary>
@@ -95,6 +107,7 @@ namespace AdbcDrivers.BigQuery
         public const string UserAuthenticationType = "user";
         public const string EntraIdAuthenticationType = "aad";
         public const string ServiceAccountAuthenticationType = "service";
+        public const string MockAuthenticationType = "mock";
         public const string TokenEndpoint = "https://accounts.google.com/o/oauth2/token";
         public const string TreatLargeDecimalAsString = "true";
 

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -192,7 +192,7 @@ namespace AdbcDrivers.BigQuery
 
                 BigQueryResults results = await ExecuteWithRetriesAsync(getJobResults, activity, cancellationContext.CancellationToken).ConfigureAwait(false);
 
-                TokenProtectedReadClientManger clientMgr = new TokenProtectedReadClientManger(Credential);
+                TokenProtectedReadClientManger clientMgr = new TokenProtectedReadClientManger(Credential, this.bigQueryConnection.TestStorageEndpoint);
                 clientMgr.UpdateToken = () => Task.Run(() =>
                 {
                     this.bigQueryConnection.SetCredential();

--- a/csharp/src/AdbcDrivers.BigQuery/TokenProtectedReadClient.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/TokenProtectedReadClient.cs
@@ -25,6 +25,7 @@ using System;
 using System.Threading.Tasks;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.BigQuery.Storage.V1;
+using Grpc.Core;
 
 namespace AdbcDrivers.BigQuery
 {
@@ -34,9 +35,11 @@ namespace AdbcDrivers.BigQuery
     internal class TokenProtectedReadClientManger : ITokenProtectedResource
     {
         BigQueryReadClient bigQueryReadClient;
+        readonly string? endpoint;
 
-        public TokenProtectedReadClientManger(GoogleCredential credential)
+        public TokenProtectedReadClientManger(GoogleCredential credential, string? testEndpoint = null)
         {
+            this.endpoint = testEndpoint;
             UpdateCredential(credential);
 
             if (bigQueryReadClient == null)
@@ -55,7 +58,17 @@ namespace AdbcDrivers.BigQuery
             }
 
             BigQueryReadClientBuilder readClientBuilder = new BigQueryReadClientBuilder();
-            readClientBuilder.Credential = credential;
+
+            if (!string.IsNullOrEmpty(endpoint))
+            {
+                readClientBuilder.Endpoint = endpoint;
+                readClientBuilder.ChannelCredentials = ChannelCredentials.Insecure;
+            }
+            else
+            {
+                readClientBuilder.Credential = credential;
+            }
+
             this.bigQueryReadClient = readClientBuilder.Build();
         }
 

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/AdbcDrivers.BigQuery.MockServer.csproj
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/AdbcDrivers.BigQuery.MockServer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Google.Cloud.BigQuery.Storage.V1" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Apache.Arrow" />
+  </ItemGroup>
+</Project>

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -123,7 +123,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             // POST /bigquery/v2/projects/{projectId}/jobs - Create a query job
             app.MapPost("/bigquery/v2/projects/{projectId}/jobs", async (HttpContext ctx, string projectId) =>
             {
-                string body = await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
+                await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
 
                 string jobId = $"mock-job-{Guid.NewGuid():N}";
 

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Threading;
+using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AdbcDrivers.BigQuery.MockServer
+{
+    /// <summary>
+    /// A self-hosted mock BigQuery server that provides both a REST API (for jobs/queries)
+    /// and a gRPC service (for the Storage Read API). Runs on random loopback ports
+    /// using HTTP (not HTTPS) for test simplicity.
+    /// </summary>
+    public sealed class BigQueryMockServer : IDisposable
+    {
+        private readonly WebApplication _restApp;
+        private readonly WebApplication _grpcApp;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly ConcurrentDictionary<string, MockJob> _jobs = new();
+
+        /// <summary>
+        /// The REST API endpoint as host:port (e.g., "127.0.0.1:12345").
+        /// Set this as the <c>adbc.bigquery.test.rest_endpoint</c> parameter.
+        /// </summary>
+        public string RestEndpoint { get; }
+
+        /// <summary>
+        /// The gRPC endpoint for the BigQuery Storage Read API as host:port (e.g., "127.0.0.1:12346").
+        /// Set this as the <c>adbc.bigquery.test.storage_endpoint</c> parameter.
+        /// </summary>
+        public string GrpcEndpoint { get; }
+
+        /// <summary>
+        /// The mock gRPC service for configuring Storage Read API responses.
+        /// </summary>
+        public MockBigQueryReadService ReadService { get; }
+
+        /// <summary>
+        /// Creates and starts a new mock BigQuery server on random loopback ports.
+        /// </summary>
+        public BigQueryMockServer()
+        {
+            ReadService = new MockBigQueryReadService();
+
+            int restPort = GetFreePort();
+            int grpcPort = GetFreePort();
+
+            _restApp = BuildRestApp(restPort);
+            _grpcApp = BuildGrpcApp(grpcPort);
+
+            _restApp.StartAsync().GetAwaiter().GetResult();
+            _grpcApp.StartAsync().GetAwaiter().GetResult();
+
+            RestEndpoint = $"127.0.0.1:{restPort}";
+            GrpcEndpoint = $"127.0.0.1:{grpcPort}";
+        }
+
+        private WebApplication BuildRestApp(int port)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.Listen(IPAddress.Loopback, port, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http1;
+                });
+            });
+
+            var app = builder.Build();
+            MapRestRoutes(app);
+            return app;
+        }
+
+        private WebApplication BuildGrpcApp(int port)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services.AddGrpc();
+            builder.Services.AddSingleton(ReadService);
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.Listen(IPAddress.Loopback, port, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            });
+
+            var app = builder.Build();
+            app.MapGrpcService<MockBigQueryReadService>();
+            return app;
+        }
+
+        private void MapRestRoutes(WebApplication app)
+        {
+            // The Google.Apis BigQuery client serializes/deserializes using
+            // Google.Apis.Json.NewtonsoftJsonSerializer. We must return JSON
+            // produced by the same serializer operating on the real model classes.
+
+            // POST /bigquery/v2/projects/{projectId}/jobs - Create a query job
+            app.MapPost("/bigquery/v2/projects/{projectId}/jobs", async (HttpContext ctx, string projectId) =>
+            {
+                string body = await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
+
+                string jobId = $"mock-job-{Guid.NewGuid():N}";
+
+                var mockJob = new MockJob
+                {
+                    JobId = jobId,
+                    ProjectId = projectId,
+                    Status = "DONE",
+                };
+                _jobs[jobId] = mockJob;
+
+                var job = CreateJobResource(mockJob);
+                string json = NewtonsoftJsonSerializer.Instance.Serialize(job);
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(json);
+            });
+
+            // GET /bigquery/v2/projects/{projectId}/jobs/{jobId} - Get job status
+            app.MapGet("/bigquery/v2/projects/{projectId}/jobs/{jobId}", async (HttpContext ctx, string projectId, string jobId) =>
+            {
+                if (!_jobs.TryGetValue(jobId, out var mockJob))
+                {
+                    ctx.Response.StatusCode = 404;
+                    return;
+                }
+
+                var job = CreateJobResource(mockJob);
+                string json = NewtonsoftJsonSerializer.Instance.Serialize(job);
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(json);
+            });
+
+            // GET /bigquery/v2/projects/{projectId}/queries/{jobId} - Get query results
+            app.MapGet("/bigquery/v2/projects/{projectId}/queries/{jobId}", async (HttpContext ctx, string projectId, string jobId) =>
+            {
+                if (!_jobs.TryGetValue(jobId, out var mockJob))
+                {
+                    ctx.Response.StatusCode = 404;
+                    return;
+                }
+
+                var response = new GetQueryResultsResponse
+                {
+                    Kind = "bigquery#getQueryResultsResponse",
+                    JobReference = new JobReference { ProjectId = projectId, JobId = jobId, Location = "US" },
+                    JobComplete = true,
+                    TotalRows = 1,
+                    Schema = new TableSchema
+                    {
+                        Fields = new[]
+                        {
+                            new TableFieldSchema { Name = "value", Type = "INTEGER", Mode = "NULLABLE" }
+                        }
+                    },
+                };
+
+                string json = NewtonsoftJsonSerializer.Instance.Serialize(response);
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(json);
+            });
+
+            // Catch-all for unhandled endpoints
+            app.MapFallback(async (HttpContext ctx) =>
+            {
+                ctx.Response.StatusCode = 404;
+                await ctx.Response.WriteAsync($"Mock server: no handler for {ctx.Request.Method} {ctx.Request.Path}");
+            });
+        }
+
+        private static Job CreateJobResource(MockJob mockJob)
+        {
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            return new Job
+            {
+                Kind = "bigquery#job",
+                Id = $"{mockJob.ProjectId}:{mockJob.JobId}",
+                JobReference = new JobReference
+                {
+                    ProjectId = mockJob.ProjectId,
+                    JobId = mockJob.JobId,
+                    Location = "US"
+                },
+                Status = new JobStatus { State = mockJob.Status },
+                Configuration = new JobConfiguration
+                {
+                    Query = new JobConfigurationQuery
+                    {
+                        DestinationTable = new TableReference
+                        {
+                            ProjectId = mockJob.ProjectId,
+                            DatasetId = "_mock_temp",
+                            TableId = $"mock_results_{mockJob.JobId}"
+                        },
+                        UseLegacySql = false,
+                    },
+                },
+                Statistics = new JobStatistics
+                {
+                    CreationTime = now,
+                    StartTime = now,
+                    EndTime = now,
+                    Query = new JobStatistics2
+                    {
+                        StatementType = "SELECT",
+                        TotalBytesProcessed = 0,
+                        TotalBytesBilled = 0,
+                    }
+                }
+            };
+        }
+
+        private static int GetFreePort()
+        {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _restApp.StopAsync().GetAwaiter().GetResult();
+            _grpcApp.StopAsync().GetAwaiter().GetResult();
+            (_restApp as IDisposable)?.Dispose();
+            (_grpcApp as IDisposable)?.Dispose();
+            _cts.Dispose();
+        }
+
+        private class MockJob
+        {
+            public string JobId { get; set; } = string.Empty;
+            public string ProjectId { get; set; } = string.Empty;
+            public string Status { get; set; } = "DONE";
+        }
+    }
+}

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -237,18 +237,16 @@ namespace AdbcDrivers.BigQuery.MockServer
 
         private static int GetFreePort()
         {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
             listener.Start();
-            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
         }
 
         public void Dispose()
         {
-            _cts.Cancel();
-            _restApp.StopAsync().GetAwaiter().GetResult();
-            _grpcApp.StopAsync().GetAwaiter().GetResult();
+            _cts.CancelAfter(TimeSpan.FromSeconds(5));
+            _restApp.StopAsync(_cts.Token).GetAwaiter().GetResult();
+            _grpcApp.StopAsync(_cts.Token).GetAwaiter().GetResult();
             (_restApp as IDisposable)?.Dispose();
             (_grpcApp as IDisposable)?.Dispose();
             _cts.Dispose();

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Cloud.BigQuery.Storage.V1;
+using Google.Protobuf;
+using Grpc.Core;
+
+namespace AdbcDrivers.BigQuery.MockServer
+{
+    /// <summary>
+    /// A mock implementation of the BigQuery Storage Read gRPC service.
+    /// Returns pre-configured Arrow data for CreateReadSession and ReadRows.
+    /// </summary>
+    public class MockBigQueryReadService : BigQueryRead.BigQueryReadBase
+    {
+        private readonly ConcurrentDictionary<string, ReadSession> _sessions = new();
+        private readonly ConcurrentDictionary<string, byte[]> _streamData = new();
+
+        /// <summary>
+        /// Default Arrow schema bytes returned when no table-specific config is found.
+        /// </summary>
+        public byte[]? DefaultArrowSchema { get; set; }
+
+        /// <summary>
+        /// Default Arrow record batch bytes returned when no table-specific config is found.
+        /// </summary>
+        public byte[]? DefaultArrowBatch { get; set; }
+
+        /// <summary>
+        /// Default row count returned for each batch.
+        /// </summary>
+        public long DefaultRowCount { get; set; } = 1;
+
+        /// <summary>
+        /// Configures mock data for a table. When a CreateReadSession is received for this table,
+        /// the service will return a session with one stream containing this Arrow data.
+        /// </summary>
+        /// <param name="tableName">The full table name (projects/X/datasets/Y/tables/Z).</param>
+        /// <param name="arrowSchema">Serialized Arrow schema bytes.</param>
+        /// <param name="arrowBatch">Serialized Arrow record batch bytes.</param>
+        /// <param name="rowCount">Number of rows in the batch.</param>
+        public void ConfigureTable(string tableName, byte[] arrowSchema, byte[] arrowBatch, long rowCount)
+        {
+            string sessionName = $"projects/mock-project/locations/us/sessions/mock-session-{Guid.NewGuid():N}";
+            string streamName = $"{sessionName}/streams/mock-stream-0";
+
+            var session = new ReadSession
+            {
+                Name = sessionName,
+                Table = tableName,
+                DataFormat = DataFormat.Arrow,
+                ArrowSchema = new ArrowSchema { SerializedSchema = ByteString.CopyFrom(arrowSchema) },
+            };
+            session.Streams.Add(new ReadStream { Name = streamName });
+
+            _sessions[tableName] = session;
+            _streamData[streamName] = arrowBatch;
+        }
+
+        public override Task<ReadSession> CreateReadSession(CreateReadSessionRequest request, ServerCallContext context)
+        {
+            string tableName = request.ReadSession.Table;
+
+            if (_sessions.TryGetValue(tableName, out var session))
+            {
+                return Task.FromResult(session);
+            }
+
+            // Fall back to default data if configured
+            if (DefaultArrowSchema != null)
+            {
+                string sessionName = $"projects/mock-project/locations/us/sessions/default-{Guid.NewGuid():N}";
+                string streamName = $"{sessionName}/streams/default-stream-0";
+
+                var defaultSession = new ReadSession
+                {
+                    Name = sessionName,
+                    Table = tableName,
+                    DataFormat = DataFormat.Arrow,
+                    ArrowSchema = new ArrowSchema { SerializedSchema = ByteString.CopyFrom(DefaultArrowSchema) },
+                };
+                defaultSession.Streams.Add(new ReadStream { Name = streamName });
+
+                // Store stream data for ReadRows
+                if (DefaultArrowBatch != null)
+                {
+                    _streamData[streamName] = DefaultArrowBatch;
+                }
+
+                return Task.FromResult(defaultSession);
+            }
+
+            // Return an empty session if nothing configured
+            var emptySession = new ReadSession
+            {
+                Name = $"projects/mock-project/locations/us/sessions/empty-{Guid.NewGuid():N}",
+                Table = tableName,
+                DataFormat = DataFormat.Arrow,
+                ArrowSchema = new ArrowSchema { SerializedSchema = ByteString.Empty },
+            };
+            return Task.FromResult(emptySession);
+        }
+
+        public override async Task ReadRows(ReadRowsRequest request, IServerStreamWriter<ReadRowsResponse> responseStream, ServerCallContext context)
+        {
+            string streamName = request.ReadStream;
+
+            if (_streamData.TryGetValue(streamName, out var batchData))
+            {
+                // Look up the session to get the schema
+                byte[]? schemaData = null;
+                foreach (var kvp in _sessions)
+                {
+                    foreach (var stream in kvp.Value.Streams)
+                    {
+                        if (stream.Name == streamName)
+                        {
+                            schemaData = kvp.Value.ArrowSchema?.SerializedSchema?.ToByteArray();
+                            break;
+                        }
+                    }
+                    if (schemaData != null) break;
+                }
+
+                // Fall back to default schema
+                schemaData ??= DefaultArrowSchema;
+
+                var response = new ReadRowsResponse
+                {
+                    ArrowRecordBatch = new ArrowRecordBatch
+                    {
+                        SerializedRecordBatch = ByteString.CopyFrom(batchData),
+                    },
+                    RowCount = DefaultRowCount,
+                };
+
+                if (schemaData != null)
+                {
+                    response.ArrowSchema = new ArrowSchema
+                    {
+                        SerializedSchema = ByteString.CopyFrom(schemaData),
+                    };
+                }
+
+                await responseStream.WriteAsync(response);
+            }
+        }
+    }
+}

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
@@ -16,8 +16,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Google.Cloud.BigQuery.Storage.V1;
 using Google.Protobuf;
@@ -32,7 +30,7 @@ namespace AdbcDrivers.BigQuery.MockServer
     public class MockBigQueryReadService : BigQueryRead.BigQueryReadBase
     {
         private readonly ConcurrentDictionary<string, ReadSession> _sessions = new();
-        private readonly ConcurrentDictionary<string, byte[]> _streamData = new();
+        private readonly ConcurrentDictionary<string, (byte[] batch, long rowCount)> _streamData = new();
 
         /// <summary>
         /// Default Arrow schema bytes returned when no table-specific config is found.
@@ -72,7 +70,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             session.Streams.Add(new ReadStream { Name = streamName });
 
             _sessions[tableName] = session;
-            _streamData[streamName] = arrowBatch;
+            _streamData[streamName] = (arrowBatch, rowCount);
         }
 
         public override Task<ReadSession> CreateReadSession(CreateReadSessionRequest request, ServerCallContext context)
@@ -102,7 +100,7 @@ namespace AdbcDrivers.BigQuery.MockServer
                 // Store stream data for ReadRows
                 if (DefaultArrowBatch != null)
                 {
-                    _streamData[streamName] = DefaultArrowBatch;
+                    _streamData[streamName] = (DefaultArrowBatch, DefaultRowCount);
                 }
 
                 return Task.FromResult(defaultSession);
@@ -123,7 +121,7 @@ namespace AdbcDrivers.BigQuery.MockServer
         {
             string streamName = request.ReadStream;
 
-            if (_streamData.TryGetValue(streamName, out var batchData))
+            if (_streamData.TryGetValue(streamName, out var streamData))
             {
                 // Look up the session to get the schema
                 byte[]? schemaData = null;
@@ -147,9 +145,9 @@ namespace AdbcDrivers.BigQuery.MockServer
                 {
                     ArrowRecordBatch = new ArrowRecordBatch
                     {
-                        SerializedRecordBatch = ByteString.CopyFrom(batchData),
+                        SerializedRecordBatch = ByteString.CopyFrom(streamData.batch),
                     },
-                    RowCount = DefaultRowCount,
+                    RowCount = streamData.rowCount,
                 };
 
                 if (schemaData != null)

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryReadService.cs
@@ -30,6 +30,7 @@ namespace AdbcDrivers.BigQuery.MockServer
     public class MockBigQueryReadService : BigQueryRead.BigQueryReadBase
     {
         private readonly ConcurrentDictionary<string, ReadSession> _sessions = new();
+        private readonly ConcurrentDictionary<string, ReadSession> _streamToSession = new();
         private readonly ConcurrentDictionary<string, (byte[] batch, long rowCount)> _streamData = new();
 
         /// <summary>
@@ -70,6 +71,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             session.Streams.Add(new ReadStream { Name = streamName });
 
             _sessions[tableName] = session;
+            _streamToSession[streamName] = session;
             _streamData[streamName] = (arrowBatch, rowCount);
         }
 
@@ -97,6 +99,8 @@ namespace AdbcDrivers.BigQuery.MockServer
                 };
                 defaultSession.Streams.Add(new ReadStream { Name = streamName });
 
+                _streamToSession[streamName] = defaultSession;
+
                 // Store stream data for ReadRows
                 if (DefaultArrowBatch != null)
                 {
@@ -123,20 +127,9 @@ namespace AdbcDrivers.BigQuery.MockServer
 
             if (_streamData.TryGetValue(streamName, out var streamData))
             {
-                // Look up the session to get the schema
-                byte[]? schemaData = null;
-                foreach (var kvp in _sessions)
-                {
-                    foreach (var stream in kvp.Value.Streams)
-                    {
-                        if (stream.Name == streamName)
-                        {
-                            schemaData = kvp.Value.ArrowSchema?.SerializedSchema?.ToByteArray();
-                            break;
-                        }
-                    }
-                    if (schemaData != null) break;
-                }
+                byte[]? schemaData = _streamToSession.TryGetValue(streamName, out var session)
+                    ? session.ArrowSchema?.SerializedSchema?.ToByteArray()
+                    : null;
 
                 // Fall back to default schema
                 schemaData ??= DefaultArrowSchema;

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/AdbcDrivers.BigQuery.Tests.csproj
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/AdbcDrivers.BigQuery.Tests.csproj
@@ -4,16 +4,16 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net8.0</TargetFrameworks>
   </PropertyGroup>
     <ItemGroup>
-     <PackageReference Include="Azure.Identity" Version="1.17.1" />
-       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-       <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
-       <PackageReference Include="xunit" Version="2.9.3" />
-       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+     <PackageReference Include="Azure.Identity" />
+       <PackageReference Include="Microsoft.NET.Test.Sdk" />
+       <PackageReference Include="System.Net.Http.WinHttpHandler" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
+       <PackageReference Include="xunit" />
+       <PackageReference Include="xunit.runner.visualstudio">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
      </PackageReference>
-     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
-     <PackageReference Include="Moq" Version="4.20.72" />
+     <PackageReference Include="Xunit.SkippableFact" />
+     <PackageReference Include="Moq" />
    </ItemGroup>
     <ItemGroup>
      <None Update="Resources\BigQueryData.sql">
@@ -27,5 +27,6 @@
      <ProjectReference Include="..\..\arrow-adbc\csharp\src\Client\Apache.Arrow.Adbc.Client.csproj" />
      <ProjectReference Include="..\..\arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj" />
      <ProjectReference Include="..\..\src\AdbcDrivers.BigQuery\AdbcDrivers.BigQuery.csproj" />
+     <ProjectReference Include="..\AdbcDrivers.BigQuery.MockServer\AdbcDrivers.BigQuery.MockServer.csproj" Condition="'$(TargetFramework)' == 'net8.0'" />
    </ItemGroup>
  </Project>

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
@@ -79,12 +79,15 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
             Assert.NotNull(result.Stream);
 
             // Read the first batch
-            RecordBatch? resultBatch = await result.Stream.ReadNextRecordBatchAsync();
-            Assert.NotNull(resultBatch);
-            Assert.Equal(1, resultBatch.Length);
+            using (result.Stream)
+            {
+                using RecordBatch? resultBatch = await result.Stream.ReadNextRecordBatchAsync();
+                Assert.NotNull(resultBatch);
+                Assert.Equal(1, resultBatch.Length);
 
-            var column = Assert.IsType<Int64Array>(resultBatch.Column(0));
-            Assert.Equal(42L, column.GetValue(0));
+                var column = Assert.IsType<Int64Array>(resultBatch.Column(0));
+                Assert.Equal(42L, column.GetValue(0));
+            }
         }
     }
 }

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if NET8_0_OR_GREATER
+
+using System.Collections.Generic;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Types;
+using AdbcDrivers.BigQuery.MockServer;
+using Xunit;
+
+namespace AdbcDrivers.BigQuery.Tests.MockServer
+{
+    [Trait("Category", "MockServer")]
+    public class MockServerTests
+    {
+        [Fact]
+        public async System.Threading.Tasks.Task CanExecuteSelectAgainstMockServer()
+        {
+            using var mockServer = new BigQueryMockServer();
+
+            // Build Arrow schema and record batch for the mock Storage Read API response
+            var schema = new Schema(new[]
+            {
+                new Field("value", Int64Type.Default, nullable: true)
+            }, null);
+
+            // Build a single record batch with value = 42
+            var int64Builder = new Int64Array.Builder();
+            int64Builder.Append(42);
+            var batch = new RecordBatch(schema, new IArrowArray[] { int64Builder.Build() }, 1);
+
+            // Serialize using the same format the BigQuery Storage API uses
+            byte[] schemaBytes = ArrowSerializationHelpers.SerializeSchema(schema);
+            byte[] batchBytes = ArrowSerializationHelpers.SerializeRecordBatch(batch);
+
+            // Configure the mock gRPC service with default data for any table
+            mockServer.ReadService.DefaultArrowSchema = schemaBytes;
+            mockServer.ReadService.DefaultArrowBatch = batchBytes;
+            mockServer.ReadService.DefaultRowCount = 1;
+
+            string projectId = "mock-project";
+            var parameters = new Dictionary<string, string>
+            {
+                { BigQueryParameters.ProjectId, projectId },
+                { BigQueryParameters.AuthenticationType, BigQueryConstants.MockAuthenticationType },
+                { BigQueryParameters.TestRestEndpoint, mockServer.RestEndpoint },
+                { BigQueryParameters.TestStorageEndpoint, mockServer.GrpcEndpoint },
+            };
+
+            using var driver = new BigQueryDriver();
+            using AdbcDatabase database = driver.Open(parameters);
+            using AdbcConnection connection = database.Connect(new Dictionary<string, string>());
+            using AdbcStatement statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 42 AS value";
+
+            // ExecuteQuery drives the full pipeline:
+            // 1. REST: POST jobs (create query job)
+            // 2. REST: GET jobs/{id} (poll job status)
+            // 3. REST: GET queries/{id} (get query results metadata)
+            // 4. gRPC: CreateReadSession (create storage read session)
+            // 5. gRPC: ReadRows (stream Arrow data)
+            QueryResult result = statement.ExecuteQuery();
+            Assert.NotNull(result);
+            Assert.NotNull(result.Stream);
+
+            // Read the first batch
+            RecordBatch? resultBatch = await result.Stream.ReadNextRecordBatchAsync();
+            Assert.NotNull(resultBatch);
+            Assert.Equal(1, resultBatch.Length);
+
+            var column = Assert.IsType<Int64Array>(resultBatch.Column(0));
+            Assert.Equal(42L, column.GetValue(0));
+        }
+    }
+}
+
+#endif

--- a/csharp/test/SmokeTests/Apache.Arrow.Adbc.SmokeTests.Drivers.BigQuery.csproj
+++ b/csharp/test/SmokeTests/Apache.Arrow.Adbc.SmokeTests.Drivers.BigQuery.csproj
@@ -11,14 +11,14 @@
       <Compile Include="..\AdbcDrivers.BigQuery.Tests\ClientTests.cs" Link="ClientTests.cs" />
     </ItemGroup>
     <ItemGroup>
-     <PackageReference Include="Apache.Arrow.Adbc.Drivers.BigQuery" Version="[$(ApacheArrowAdbcDriversBigQueryVersion)]" />
-     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-     <PackageReference Include="xunit" Version="2.5.3" />
-     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+     <PackageReference Include="Apache.Arrow.Adbc.Drivers.BigQuery" VersionOverride="[$(ApacheArrowAdbcDriversBigQueryVersion)]" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+     <PackageReference Include="xunit" />
+     <PackageReference Include="xunit.runner.visualstudio">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
      </PackageReference>
-     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+     <PackageReference Include="Xunit.SkippableFact" />
    </ItemGroup>
     <ItemGroup>
       <Folder Include="Resources\" />


### PR DESCRIPTION
## What's Changed

- Adds a new AdbcDrivers.BigQuery.MockServer project that hosts in-process servers for the BigQuery and Storage APIs so driver-level tests can exercise driver functionality without needing to talk to or pay for an actual BigQuery service.
- Adds two new connection parameters to the driver clearly marked as being for testing. These allow the driver to connect to the mock server instead of the real one.
- Adds a single end-to-end test which runs a simple query against the mock server and verifies the result.