### PR TITLE
feat(csharp): implement bulk ingestion via BigQuery Storage Write API

### DIFF
--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryBulkIngest.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryBulkIngest.cs
@@ -1,0 +1,489 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Google;
+using Google.Cloud.BigQuery.Storage.V1;
+using Google.Cloud.BigQuery.V2;
+using Google.Protobuf;
+using ArrowRecordBatch = Google.Cloud.BigQuery.Storage.V1.ArrowRecordBatch;
+using ArrowSchema = Google.Cloud.BigQuery.Storage.V1.ArrowSchema;
+using TableFieldSchema = Google.Apis.Bigquery.v2.Data.TableFieldSchema;
+
+namespace AdbcDrivers.BigQuery
+{
+    /// <summary>
+    /// Implements bulk ingestion using the BigQuery Storage Write API with Arrow IPC format.
+    /// Data flows columnar end-to-end: Arrow RecordBatch → IPC serialize → gRPC → BigQuery.
+    /// Uses a PENDING write stream for atomic commit.
+    /// </summary>
+    internal sealed class BigQueryBulkIngest
+    {
+        private readonly BigQueryClient _restClient;
+        private readonly BigQueryWriteClient _writeClient;
+        private readonly string _projectId;
+
+        public BigQueryBulkIngest(BigQueryClient restClient, BigQueryWriteClient writeClient, string projectId)
+        {
+            _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
+            _writeClient = writeClient ?? throw new ArgumentNullException(nameof(writeClient));
+            _projectId = projectId ?? throw new ArgumentNullException(nameof(projectId));
+        }
+
+        /// <summary>
+        /// Executes bulk ingestion of the bound data into the target table.
+        /// </summary>
+        public async Task<UpdateResult> ExecuteAsync(
+            string? targetCatalog,
+            string? targetDbSchema,
+            string targetTable,
+            BulkIngestMode mode,
+            RecordBatch? boundBatch,
+            IArrowArrayStream? boundStream,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(targetTable))
+                throw new AdbcException("Target table name is required for bulk ingest", AdbcStatusCode.InvalidArgument);
+
+            if (boundBatch == null && boundStream == null)
+                throw new AdbcException("No data bound for bulk ingest. Call Bind() or BindStream() before ExecuteUpdate().", AdbcStatusCode.InvalidState);
+
+            string catalog = targetCatalog ?? _projectId;
+            if (string.IsNullOrEmpty(targetDbSchema))
+                throw new AdbcException("Target dataset (schema) is required for bulk ingest", AdbcStatusCode.InvalidArgument);
+
+            string tableReference = $"projects/{catalog}/datasets/{targetDbSchema}/tables/{targetTable}";
+
+            // Determine the Arrow schema from the bound data
+            Schema arrowSchema;
+            if (boundBatch != null)
+            {
+                arrowSchema = boundBatch.Schema;
+            }
+            else
+            {
+                arrowSchema = boundStream!.Schema;
+            }
+
+            // Handle table lifecycle based on BulkIngestMode
+            await HandleTableLifecycleAsync(catalog, targetDbSchema!, targetTable, mode, arrowSchema, cancellationToken).ConfigureAwait(false);
+
+            // Create a PENDING write stream for atomic commit
+            WriteStream writeStream = await _writeClient.CreateWriteStreamAsync(
+                new CreateWriteStreamRequest
+                {
+                    Parent = tableReference,
+                    WriteStream = new WriteStream { Type = WriteStream.Types.Type.Pending }
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            long totalRows = 0;
+
+            try
+            {
+                // Open the bidirectional streaming call
+                using BigQueryWriteClient.AppendRowsStream appendStream = _writeClient.AppendRows();
+
+                // Serialize the Arrow schema (sent with first request)
+                byte[] schemaBytes = SerializeSchema(arrowSchema);
+
+                if (boundBatch != null)
+                {
+                    totalRows = await AppendBatchAsync(appendStream, writeStream.Name, schemaBytes, boundBatch, isFirst: true, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    bool isFirst = true;
+                    while (true)
+                    {
+                        RecordBatch? batch = await boundStream!.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+                        if (batch == null) break;
+
+                        totalRows += await AppendBatchAsync(appendStream, writeStream.Name, schemaBytes, batch, isFirst, cancellationToken).ConfigureAwait(false);
+                        isFirst = false;
+                    }
+                }
+
+                // Signal end of writes
+                await appendStream.WriteCompleteAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not AdbcException)
+            {
+                throw new AdbcException($"Failed to append rows: {ex.Message}", AdbcStatusCode.IOError, ex);
+            }
+
+            // Finalize the write stream
+            await _writeClient.FinalizeWriteStreamAsync(
+                new FinalizeWriteStreamRequest { Name = writeStream.Name },
+                cancellationToken).ConfigureAwait(false);
+
+            // Atomically commit
+            await _writeClient.BatchCommitWriteStreamsAsync(
+                new BatchCommitWriteStreamsRequest
+                {
+                    Parent = tableReference,
+                    WriteStreams = { writeStream.Name }
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            return new UpdateResult(totalRows);
+        }
+
+        private async Task<long> AppendBatchAsync(
+            BigQueryWriteClient.AppendRowsStream appendStream,
+            string writeStreamName,
+            byte[] schemaBytes,
+            RecordBatch batch,
+            bool isFirst,
+            CancellationToken cancellationToken)
+        {
+            // Normalize types BigQuery requires (microsecond precision)
+            batch = NormalizeBatch(batch);
+
+            byte[] batchBytes = SerializeRecordBatch(batch);
+
+            var request = new AppendRowsRequest
+            {
+                WriteStream = writeStreamName,
+                ArrowRows = new AppendRowsRequest.Types.ArrowData
+                {
+                    Rows = new ArrowRecordBatch
+                    {
+                        SerializedRecordBatch = ByteString.CopyFrom(batchBytes)
+                    }
+                }
+            };
+
+            // Include schema on first request
+            if (isFirst)
+            {
+                request.ArrowRows.WriterSchema = new ArrowSchema
+                {
+                    SerializedSchema = ByteString.CopyFrom(schemaBytes)
+                };
+            }
+
+            await appendStream.WriteAsync(request).ConfigureAwait(false);
+
+            // Read and check response
+            var responseStream = appendStream.GetResponseStream();
+            if (await responseStream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var response = responseStream.Current;
+                if (response.Error != null && response.Error.Code != 0)
+                {
+                    throw new AdbcException(
+                        $"BigQuery append failed: {response.Error.Message}",
+                        AdbcStatusCode.IOError);
+                }
+            }
+
+            return batch.Length;
+        }
+
+        private async Task HandleTableLifecycleAsync(
+            string projectId,
+            string datasetId,
+            string tableId,
+            BulkIngestMode mode,
+            Schema arrowSchema,
+            CancellationToken cancellationToken)
+        {
+            var tableRef = _restClient.GetTableReference(projectId, datasetId, tableId);
+            BigQueryTable? existingTable = null;
+            bool tableExists;
+
+            try
+            {
+                existingTable = await _restClient.GetTableAsync(tableRef, cancellationToken: cancellationToken).ConfigureAwait(false);
+                tableExists = true;
+            }
+            catch (GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                tableExists = false;
+            }
+
+            switch (mode)
+            {
+                case BulkIngestMode.Create:
+                    if (tableExists)
+                        throw new AdbcException($"Table {tableId} already exists", AdbcStatusCode.AlreadyExists);
+                    await CreateTableAsync(projectId, datasetId, tableId, arrowSchema, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case BulkIngestMode.Append:
+                    if (!tableExists)
+                        throw new AdbcException($"Table {tableId} does not exist", AdbcStatusCode.NotFound);
+                    break;
+
+                case BulkIngestMode.Replace:
+                    if (tableExists)
+                        await _restClient.DeleteTableAsync(tableRef, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await CreateTableAsync(projectId, datasetId, tableId, arrowSchema, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case BulkIngestMode.CreateAppend:
+                    if (!tableExists)
+                        await CreateTableAsync(projectId, datasetId, tableId, arrowSchema, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    throw new AdbcException($"Unsupported bulk ingest mode: {mode}", AdbcStatusCode.NotImplemented);
+            }
+        }
+
+        private async Task CreateTableAsync(
+            string projectId,
+            string datasetId,
+            string tableId,
+            Schema arrowSchema,
+            CancellationToken cancellationToken)
+        {
+            var bqSchema = ArrowSchemaToBigQuerySchema(arrowSchema);
+            var tableRef = _restClient.GetTableReference(projectId, datasetId, tableId);
+            await _restClient.CreateTableAsync(tableRef, bqSchema, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        #region Arrow type normalization
+
+        /// <summary>
+        /// Normalizes Arrow types to those BigQuery accepts.
+        /// BigQuery assumes microsecond precision for all time/timestamp values.
+        /// </summary>
+        internal static RecordBatch NormalizeBatch(RecordBatch batch)
+        {
+            bool needsNormalization = false;
+            foreach (var field in batch.Schema.FieldsList)
+            {
+                if (NeedsNormalization(field.DataType))
+                {
+                    needsNormalization = true;
+                    break;
+                }
+            }
+
+            if (!needsNormalization)
+                return batch;
+
+            var newFields = new List<Field>(batch.Schema.FieldsList.Count);
+            var newArrays = new IArrowArray[batch.ColumnCount];
+
+            for (int i = 0; i < batch.ColumnCount; i++)
+            {
+                var field = batch.Schema.FieldsList[i];
+                var array = batch.Column(i);
+
+                if (NeedsNormalization(field.DataType))
+                {
+                    var (newType, newArray) = NormalizeArray(field.DataType, array);
+                    newFields.Add(new Field(field.Name, newType, field.IsNullable, field.Metadata));
+                    newArrays[i] = newArray;
+                }
+                else
+                {
+                    newFields.Add(field);
+                    newArrays[i] = array;
+                }
+            }
+
+            var newSchema = new Schema(newFields, batch.Schema.Metadata);
+            return new RecordBatch(newSchema, newArrays, batch.Length);
+        }
+
+        private static bool NeedsNormalization(IArrowType type)
+        {
+            return type switch
+            {
+                Time32Type => true,
+                Time64Type t => t.Unit != TimeUnit.Microsecond,
+                TimestampType t => t.Unit != TimeUnit.Microsecond,
+                _ => false
+            };
+        }
+
+        private static (IArrowType, IArrowArray) NormalizeArray(IArrowType type, IArrowArray array)
+        {
+            switch (type)
+            {
+                case Time32Type t32:
+                {
+                    var source = (Time32Array)array;
+                    var builder = new Time64Array.Builder(TimeUnit.Microsecond);
+                    long multiplier = t32.Unit == TimeUnit.Second ? 1_000_000L : 1_000L;
+                    for (int i = 0; i < source.Length; i++)
+                    {
+                        if (source.IsNull(i))
+                            builder.AppendNull();
+                        else
+                            builder.Append(source.GetValue(i)!.Value * multiplier);
+                    }
+                    return (new Time64Type(TimeUnit.Microsecond), builder.Build());
+                }
+                case Time64Type t64:
+                {
+                    var source = (Time64Array)array;
+                    var builder = new Time64Array.Builder(TimeUnit.Microsecond);
+                    // t64.Unit must be Nanosecond (Microsecond is handled by NeedsNormalization)
+                    for (int i = 0; i < source.Length; i++)
+                    {
+                        if (source.IsNull(i))
+                            builder.AppendNull();
+                        else
+                            builder.Append(source.GetValue(i)!.Value / 1_000L);
+                    }
+                    return (new Time64Type(TimeUnit.Microsecond), builder.Build());
+                }
+                case TimestampType ts:
+                {
+                    var source = (TimestampArray)array;
+                    var targetType = new TimestampType(TimeUnit.Microsecond, ts.Timezone);
+                    var builder = new TimestampArray.Builder(targetType);
+                    for (int i = 0; i < source.Length; i++)
+                    {
+                        if (source.IsNull(i))
+                            builder.AppendNull();
+                        else
+                            builder.Append(source.GetTimestamp(i)!.Value);
+                    }
+                    return (targetType, builder.Build());
+                }
+                default:
+                    throw new InvalidOperationException($"Unexpected type for normalization: {type}");
+            }
+        }
+
+        #endregion
+
+        #region Arrow schema to BigQuery schema conversion
+
+        /// <summary>
+        /// Converts an Arrow schema to a BigQuery table schema for table creation.
+        /// </summary>
+        internal static Google.Apis.Bigquery.v2.Data.TableSchema ArrowSchemaToBigQuerySchema(Schema arrowSchema)
+        {
+            var fields = new List<TableFieldSchema>(arrowSchema.FieldsList.Count);
+            foreach (var field in arrowSchema.FieldsList)
+            {
+                fields.Add(ArrowFieldToBigQueryField(field));
+            }
+            return new Google.Apis.Bigquery.v2.Data.TableSchema { Fields = fields };
+        }
+
+        private static TableFieldSchema ArrowFieldToBigQueryField(Field field)
+        {
+            var bqField = new TableFieldSchema
+            {
+                Name = field.Name,
+                Mode = field.IsNullable ? "NULLABLE" : "REQUIRED",
+            };
+
+            switch (field.DataType)
+            {
+                case BinaryType:
+                    bqField.Type = "BYTES";
+                    break;
+                case Decimal128Type d128:
+                    bqField.Type = "NUMERIC";
+                    bqField.Precision = d128.Precision;
+                    bqField.Scale = d128.Scale;
+                    break;
+                case Decimal256Type d256:
+                    bqField.Type = "BIGNUMERIC";
+                    bqField.Precision = d256.Precision;
+                    bqField.Scale = d256.Scale;
+                    break;
+                case FixedSizeBinaryType:
+                    bqField.Type = "BYTES";
+                    break;
+                case BooleanType:
+                    bqField.Type = "BOOLEAN";
+                    break;
+                case Date32Type:
+                case Date64Type:
+                    bqField.Type = "DATE";
+                    break;
+                case FloatType:
+                case DoubleType:
+                    bqField.Type = "FLOAT";
+                    break;
+                case Int8Type:
+                case Int16Type:
+                case Int32Type:
+                case Int64Type:
+                case UInt8Type:
+                case UInt16Type:
+                case UInt32Type:
+                case UInt64Type:
+                    bqField.Type = "INTEGER";
+                    break;
+                case StringType:
+                    bqField.Type = "STRING";
+                    break;
+                case Time32Type:
+                case Time64Type:
+                    bqField.Type = "TIME";
+                    break;
+                case TimestampType ts:
+                    bqField.Type = string.IsNullOrEmpty(ts.Timezone) ? "DATETIME" : "TIMESTAMP";
+                    break;
+                case StructType structType:
+                    bqField.Type = "RECORD";
+                    var nestedFields = new List<TableFieldSchema>();
+                    foreach (var nestedField in structType.Fields)
+                    {
+                        nestedFields.Add(ArrowFieldToBigQueryField(nestedField));
+                    }
+                    bqField.Fields = nestedFields;
+                    break;
+                case ListType listType:
+                    var elementField = ArrowFieldToBigQueryField(listType.ValueField);
+                    bqField.Type = elementField.Type;
+                    bqField.Mode = "REPEATED";
+                    bqField.Fields = elementField.Fields;
+                    bqField.Precision = elementField.Precision;
+                    bqField.Scale = elementField.Scale;
+                    break;
+                default:
+                    throw new AdbcException($"Unsupported Arrow type for BigQuery ingest: {field.DataType}", AdbcStatusCode.NotImplemented);
+            }
+
+            return bqField;
+        }
+
+        #endregion
+
+        #region Arrow IPC serialization
+
+        private static byte[] SerializeSchema(Schema schema)
+        {
+            return ArrowSerializationHelpers.SerializeSchema(schema);
+        }
+
+        private static byte[] SerializeRecordBatch(RecordBatch batch)
+        {
+            return ArrowSerializationHelpers.SerializeRecordBatch(batch);
+        }
+
+        #endregion
+    }
+}

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryBulkIngest.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryBulkIngest.cs
@@ -85,8 +85,13 @@ namespace AdbcDrivers.BigQuery
                 arrowSchema = boundStream!.Schema;
             }
 
+            // Normalize the schema to match what NormalizeBatch will produce,
+            // so the serialized schema sent with AppendRows is consistent with
+            // the serialized record batches.
+            Schema normalizedSchema = NormalizeSchema(arrowSchema);
+
             // Handle table lifecycle based on BulkIngestMode
-            await HandleTableLifecycleAsync(catalog, targetDbSchema!, targetTable, mode, arrowSchema, cancellationToken).ConfigureAwait(false);
+            await HandleTableLifecycleAsync(catalog, targetDbSchema!, targetTable, mode, normalizedSchema, cancellationToken).ConfigureAwait(false);
 
             // Create a PENDING write stream for atomic commit
             WriteStream writeStream = await _writeClient.CreateWriteStreamAsync(
@@ -105,7 +110,7 @@ namespace AdbcDrivers.BigQuery
                 using BigQueryWriteClient.AppendRowsStream appendStream = _writeClient.AppendRows();
 
                 // Serialize the Arrow schema (sent with first request)
-                byte[] schemaBytes = SerializeSchema(arrowSchema);
+                byte[] schemaBytes = SerializeSchema(normalizedSchema);
 
                 if (boundBatch != null)
                 {
@@ -267,6 +272,43 @@ namespace AdbcDrivers.BigQuery
         #region Arrow type normalization
 
         /// <summary>
+        /// Normalizes an Arrow schema to match what NormalizeBatch will produce.
+        /// This ensures the schema sent with AppendRows is consistent with the
+        /// serialized record batches.
+        /// </summary>
+        internal static Schema NormalizeSchema(Schema schema)
+        {
+            bool needsNormalization = false;
+            foreach (var field in schema.FieldsList)
+            {
+                if (NeedsNormalization(field.DataType))
+                {
+                    needsNormalization = true;
+                    break;
+                }
+            }
+
+            if (!needsNormalization)
+                return schema;
+
+            var newFields = new List<Field>(schema.FieldsList.Count);
+            foreach (var field in schema.FieldsList)
+            {
+                if (NeedsNormalization(field.DataType))
+                {
+                    IArrowType normalizedType = NormalizeType(field.DataType);
+                    newFields.Add(new Field(field.Name, normalizedType, field.IsNullable, field.Metadata));
+                }
+                else
+                {
+                    newFields.Add(field);
+                }
+            }
+
+            return new Schema(newFields, schema.Metadata);
+        }
+
+        /// <summary>
         /// Normalizes Arrow types to those BigQuery accepts.
         /// BigQuery assumes microsecond precision for all time/timestamp values.
         /// </summary>
@@ -318,6 +360,17 @@ namespace AdbcDrivers.BigQuery
                 Time64Type t => t.Unit != TimeUnit.Microsecond,
                 TimestampType t => t.Unit != TimeUnit.Microsecond,
                 _ => false
+            };
+        }
+
+        private static IArrowType NormalizeType(IArrowType type)
+        {
+            return type switch
+            {
+                Time32Type => new Time64Type(TimeUnit.Microsecond),
+                Time64Type => new Time64Type(TimeUnit.Microsecond),
+                TimestampType ts => new TimestampType(TimeUnit.Microsecond, ts.Timezone),
+                _ => type
             };
         }
 

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -207,6 +207,31 @@ namespace AdbcDrivers.BigQuery
 
         internal string? TestStorageEndpoint { get; private set; }
 
+        internal string? ProjectId
+        {
+            get
+            {
+                if (Client != null) return Client.ProjectId;
+                properties.TryGetValue(BigQueryParameters.ProjectId, out string? pid);
+                return pid;
+            }
+        }
+
+        public override AdbcStatement BulkIngest(string targetTableName, BulkIngestMode mode)
+        {
+            return BulkIngest(null, null, targetTableName, mode, false);
+        }
+
+        public override AdbcStatement BulkIngest(string? targetCatalog, string? targetDbSchema, string targetTableName, BulkIngestMode mode, bool isTemporary)
+        {
+            if (isTemporary)
+                throw AdbcException.NotImplemented("Temporary table bulk ingest is not supported for BigQuery");
+
+            var statement = new BigQueryStatement(this);
+            statement.SetBulkIngest(targetCatalog, targetDbSchema, targetTableName, mode);
+            return statement;
+        }
+
         public override string AssemblyVersion => BigQueryUtils.BigQueryAssemblyVersion;
 
         public override string AssemblyName => BigQueryUtils.BigQueryAssemblyName;

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -60,6 +60,15 @@ namespace AdbcDrivers.BigQuery
         string? schemaName = null;
         string? tableName = null;
 
+        // Bulk ingest state
+        private bool _isBulkIngest;
+        private string? _ingestTargetCatalog;
+        private string? _ingestTargetDbSchema;
+        private string? _ingestTargetTable;
+        private BulkIngestMode _ingestMode;
+        private RecordBatch? _boundBatch;
+        private IArrowArrayStream? _boundStream;
+
         public BigQueryStatement(BigQueryConnection bigQueryConnection) : base(bigQueryConnection)
         {
             if (bigQueryConnection == null) { throw new AdbcException($"{nameof(bigQueryConnection)} cannot be null", AdbcStatusCode.InvalidArgument); }
@@ -74,6 +83,27 @@ namespace AdbcDrivers.BigQuery
         public Func<Task>? UpdateToken { get; set; }
 
         internal Dictionary<string, string>? Options { get; set; }
+
+        internal void SetBulkIngest(string? targetCatalog, string? targetDbSchema, string targetTable, BulkIngestMode mode)
+        {
+            _isBulkIngest = true;
+            _ingestTargetCatalog = targetCatalog;
+            _ingestTargetDbSchema = targetDbSchema;
+            _ingestTargetTable = targetTable;
+            _ingestMode = mode;
+        }
+
+        public override void Bind(RecordBatch batch, Schema schema)
+        {
+            _boundBatch = batch ?? throw new ArgumentNullException(nameof(batch));
+            _boundStream = null;
+        }
+
+        public override void BindStream(IArrowArrayStream stream)
+        {
+            _boundStream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _boundBatch = null;
+        }
 
         private BigQueryClient Client => this.bigQueryConnection.Client ?? throw new AdbcException("Client cannot be null");
 
@@ -798,6 +828,11 @@ namespace AdbcDrivers.BigQuery
 
         private async Task<UpdateResult> ExecuteUpdateInternalAsync()
         {
+            if (_isBulkIngest)
+            {
+                return await ExecuteBulkIngestAsync().ConfigureAwait(false);
+            }
+
             return await this.TraceActivityAsync(async activity =>
             {
                 GetQueryResultsOptions getQueryResultsOptions = new GetQueryResultsOptions();
@@ -835,6 +870,44 @@ namespace AdbcDrivers.BigQuery
                 activity?.AddTag(SemanticConventions.Db.Response.ReturnedRows, updatedRows);
                 return new UpdateResult(updatedRows);
             }, ClassName + "." + nameof(ExecuteUpdateInternalAsync));
+        }
+
+        private async Task<UpdateResult> ExecuteBulkIngestAsync()
+        {
+            var writeClient = CreateBigQueryWriteClient();
+            var ingest = new BigQueryBulkIngest(Client, writeClient, this.bigQueryConnection.ProjectId!);
+            try
+            {
+                return await ingest.ExecuteAsync(
+                    _ingestTargetCatalog,
+                    _ingestTargetDbSchema,
+                    _ingestTargetTable!,
+                    _ingestMode,
+                    _boundBatch,
+                    _boundStream).ConfigureAwait(false);
+            }
+            finally
+            {
+                await BigQueryWriteClient.ShutdownDefaultChannelsAsync().ConfigureAwait(false);
+            }
+        }
+
+        private BigQueryWriteClient CreateBigQueryWriteClient()
+        {
+            var builder = new BigQueryWriteClientBuilder();
+            string? endpoint = this.bigQueryConnection.TestStorageEndpoint;
+
+            if (!string.IsNullOrEmpty(endpoint))
+            {
+                builder.Endpoint = endpoint;
+                builder.ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure;
+            }
+            else
+            {
+                builder.GoogleCredential = Credential;
+            }
+
+            return builder.Build();
         }
 
         private Schema TranslateSchema(TableSchema schema)

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -876,20 +876,13 @@ namespace AdbcDrivers.BigQuery
         {
             var writeClient = CreateBigQueryWriteClient();
             var ingest = new BigQueryBulkIngest(Client, writeClient, this.bigQueryConnection.ProjectId!);
-            try
-            {
-                return await ingest.ExecuteAsync(
-                    _ingestTargetCatalog,
-                    _ingestTargetDbSchema,
-                    _ingestTargetTable!,
-                    _ingestMode,
-                    _boundBatch,
-                    _boundStream).ConfigureAwait(false);
-            }
-            finally
-            {
-                await BigQueryWriteClient.ShutdownDefaultChannelsAsync().ConfigureAwait(false);
-            }
+            return await ingest.ExecuteAsync(
+                _ingestTargetCatalog,
+                _ingestTargetDbSchema,
+                _ingestTargetTable!,
+                _ingestMode,
+                _boundBatch,
+                _boundStream).ConfigureAwait(false);
         }
 
         private BigQueryWriteClient CreateBigQueryWriteClient()

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -216,12 +216,18 @@ namespace AdbcDrivers.BigQuery.MockServer
             // POST /bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables - Create table
             app.MapPost("/bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables", async (HttpContext ctx, string projectId, string datasetId) =>
             {
-                System.IO.Stream bodyStream = ctx.Request.Body;
+                string body;
                 if (string.Equals(ctx.Request.Headers["Content-Encoding"].ToString(), "gzip", StringComparison.OrdinalIgnoreCase))
                 {
-                    bodyStream = new GZipStream(bodyStream, CompressionMode.Decompress);
+                    await using var gzipStream = new GZipStream(ctx.Request.Body, CompressionMode.Decompress, leaveOpen: true);
+                    using var reader = new System.IO.StreamReader(gzipStream);
+                    body = await reader.ReadToEndAsync();
                 }
-                string body = await new System.IO.StreamReader(bodyStream).ReadToEndAsync();
+                else
+                {
+                    using var reader = new System.IO.StreamReader(ctx.Request.Body);
+                    body = await reader.ReadToEndAsync();
+                }
                 var table = NewtonsoftJsonSerializer.Instance.Deserialize<Table>(body);
                 if (table == null)
                 {
@@ -230,6 +236,13 @@ namespace AdbcDrivers.BigQuery.MockServer
                 }
 
                 string tableId = table.TableReference?.TableId ?? "";
+                if (string.IsNullOrEmpty(tableId))
+                {
+                    ctx.Response.StatusCode = 400;
+                    var badRequest = new { error = new { code = 400, message = "tableReference.tableId is required", status = "INVALID_ARGUMENT" } };
+                    await ctx.Response.WriteAsJsonAsync(badRequest);
+                    return;
+                }
                 string key = $"{projectId}.{datasetId}.{tableId}";
 
                 if (_tables.ContainsKey(key))

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -16,8 +16,10 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.IO.Compression;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Google.Apis.Bigquery.v2.Data;
 using Google.Apis.Json;
 using Microsoft.AspNetCore.Builder;
@@ -40,6 +42,7 @@ namespace AdbcDrivers.BigQuery.MockServer
         private readonly WebApplication _grpcApp;
         private readonly CancellationTokenSource _cts = new();
         private readonly ConcurrentDictionary<string, MockJob> _jobs = new();
+        private readonly ConcurrentDictionary<string, Table> _tables = new();
 
         /// <summary>
         /// The REST API endpoint as host:port (e.g., "127.0.0.1:12345").
@@ -59,11 +62,17 @@ namespace AdbcDrivers.BigQuery.MockServer
         public MockBigQueryReadService ReadService { get; }
 
         /// <summary>
+        /// The mock gRPC service for tracking Storage Write API requests.
+        /// </summary>
+        public MockBigQueryWriteService WriteService { get; }
+
+        /// <summary>
         /// Creates and starts a new mock BigQuery server on random loopback ports.
         /// </summary>
         public BigQueryMockServer()
         {
             ReadService = new MockBigQueryReadService();
+            WriteService = new MockBigQueryWriteService();
 
             int restPort = GetFreePort();
             int grpcPort = GetFreePort();
@@ -101,6 +110,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             builder.Logging.ClearProviders();
             builder.Services.AddGrpc();
             builder.Services.AddSingleton(ReadService);
+            builder.Services.AddSingleton(WriteService);
             builder.WebHost.ConfigureKestrel(options =>
             {
                 options.Listen(IPAddress.Loopback, port, listenOptions =>
@@ -111,6 +121,7 @@ namespace AdbcDrivers.BigQuery.MockServer
 
             var app = builder.Build();
             app.MapGrpcService<MockBigQueryReadService>();
+            app.MapGrpcService<MockBigQueryWriteService>();
             return app;
         }
 
@@ -183,6 +194,71 @@ namespace AdbcDrivers.BigQuery.MockServer
                 string json = NewtonsoftJsonSerializer.Instance.Serialize(response);
                 ctx.Response.ContentType = "application/json";
                 await ctx.Response.WriteAsync(json);
+            });
+
+            // GET /bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables/{tableId} - Get table
+            app.MapGet("/bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables/{tableId}", async (HttpContext ctx, string projectId, string datasetId, string tableId) =>
+            {
+                string key = $"{projectId}.{datasetId}.{tableId}";
+                if (!_tables.TryGetValue(key, out var table))
+                {
+                    ctx.Response.StatusCode = 404;
+                    var error = new { error = new { code = 404, message = $"Not found: Table {projectId}:{datasetId}.{tableId}", status = "NOT_FOUND" } };
+                    await ctx.Response.WriteAsJsonAsync(error);
+                    return;
+                }
+
+                string json = NewtonsoftJsonSerializer.Instance.Serialize(table);
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(json);
+            });
+
+            // POST /bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables - Create table
+            app.MapPost("/bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables", async (HttpContext ctx, string projectId, string datasetId) =>
+            {
+                System.IO.Stream bodyStream = ctx.Request.Body;
+                if (string.Equals(ctx.Request.Headers["Content-Encoding"].ToString(), "gzip", StringComparison.OrdinalIgnoreCase))
+                {
+                    bodyStream = new GZipStream(bodyStream, CompressionMode.Decompress);
+                }
+                string body = await new System.IO.StreamReader(bodyStream).ReadToEndAsync();
+                var table = NewtonsoftJsonSerializer.Instance.Deserialize<Table>(body);
+                if (table == null)
+                {
+                    ctx.Response.StatusCode = 400;
+                    return;
+                }
+
+                string tableId = table.TableReference?.TableId ?? "";
+                string key = $"{projectId}.{datasetId}.{tableId}";
+
+                if (_tables.ContainsKey(key))
+                {
+                    ctx.Response.StatusCode = 409;
+                    var error = new { error = new { code = 409, message = $"Already Exists: Table {projectId}:{datasetId}.{tableId}", status = "ALREADY_EXISTS" } };
+                    await ctx.Response.WriteAsJsonAsync(error);
+                    return;
+                }
+
+                table.TableReference ??= new TableReference();
+                table.TableReference.ProjectId = projectId;
+                table.TableReference.DatasetId = datasetId;
+                table.Kind = "bigquery#table";
+                _tables[key] = table;
+
+                string json = NewtonsoftJsonSerializer.Instance.Serialize(table);
+                ctx.Response.ContentType = "application/json";
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.WriteAsync(json);
+            });
+
+            // DELETE /bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables/{tableId} - Delete table
+            app.MapDelete("/bigquery/v2/projects/{projectId}/datasets/{datasetId}/tables/{tableId}", (HttpContext ctx, string projectId, string datasetId, string tableId) =>
+            {
+                string key = $"{projectId}.{datasetId}.{tableId}";
+                _tables.TryRemove(key, out _);
+                ctx.Response.StatusCode = 204;
+                return Task.CompletedTask;
             });
 
             // Catch-all for unhandled endpoints

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryWriteService.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryWriteService.cs
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Cloud.BigQuery.Storage.V1;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
+namespace AdbcDrivers.BigQuery.MockServer
+{
+    /// <summary>
+    /// Mock implementation of the BigQuery Storage Write API for testing bulk ingestion.
+    /// Tracks all received data for verification in tests.
+    /// </summary>
+    public class MockBigQueryWriteService : BigQueryWrite.BigQueryWriteBase
+    {
+        private int _streamCounter;
+        private readonly ConcurrentDictionary<string, WriteStreamInfo> _streams = new();
+
+        /// <summary>
+        /// Gets all write stream info for verification in tests.
+        /// </summary>
+        public IReadOnlyDictionary<string, WriteStreamInfo> Streams => _streams;
+
+        /// <summary>
+        /// Gets the list of committed stream names (from BatchCommitWriteStreams calls).
+        /// </summary>
+        public ConcurrentBag<string> CommittedStreams { get; } = new();
+
+        public override Task<WriteStream> CreateWriteStream(CreateWriteStreamRequest request, ServerCallContext context)
+        {
+            int id = System.Threading.Interlocked.Increment(ref _streamCounter);
+            string streamName = $"{request.Parent}/streams/mock_stream_{id}";
+
+            var info = new WriteStreamInfo(streamName, request.WriteStream.Type);
+            _streams[streamName] = info;
+
+            return Task.FromResult(new WriteStream
+            {
+                Name = streamName,
+                Type = request.WriteStream.Type,
+                CreateTime = Timestamp.FromDateTime(DateTime.UtcNow),
+            });
+        }
+
+        public override async Task AppendRows(
+            IAsyncStreamReader<AppendRowsRequest> requestStream,
+            IServerStreamWriter<AppendRowsResponse> responseStream,
+            ServerCallContext context)
+        {
+            long offset = 0;
+
+            while (await requestStream.MoveNext())
+            {
+                var request = requestStream.Current;
+
+                if (_streams.TryGetValue(request.WriteStream, out var streamInfo))
+                {
+                    if (request.ArrowRows != null)
+                    {
+                        if (request.ArrowRows.WriterSchema?.SerializedSchema != null)
+                        {
+                            streamInfo.SchemaBytes = request.ArrowRows.WriterSchema.SerializedSchema.ToByteArray();
+                        }
+
+                        if (request.ArrowRows.Rows?.SerializedRecordBatch != null)
+                        {
+                            streamInfo.RecordBatches.Add(request.ArrowRows.Rows.SerializedRecordBatch.ToByteArray());
+                        }
+                    }
+                }
+
+                var response = new AppendRowsResponse
+                {
+                    AppendResult = new AppendRowsResponse.Types.AppendResult
+                    {
+                        Offset = offset
+                    }
+                };
+
+                await responseStream.WriteAsync(response);
+                offset++;
+            }
+        }
+
+        public override Task<FinalizeWriteStreamResponse> FinalizeWriteStream(FinalizeWriteStreamRequest request, ServerCallContext context)
+        {
+            if (_streams.TryGetValue(request.Name, out var streamInfo))
+            {
+                streamInfo.Finalized = true;
+            }
+
+            return Task.FromResult(new FinalizeWriteStreamResponse
+            {
+                RowCount = _streams.TryGetValue(request.Name, out var info) ? info.RecordBatches.Count : 0
+            });
+        }
+
+        public override Task<BatchCommitWriteStreamsResponse> BatchCommitWriteStreams(BatchCommitWriteStreamsRequest request, ServerCallContext context)
+        {
+            foreach (var streamName in request.WriteStreams)
+            {
+                CommittedStreams.Add(streamName);
+            }
+
+            return Task.FromResult(new BatchCommitWriteStreamsResponse
+            {
+                CommitTime = Timestamp.FromDateTime(DateTime.UtcNow)
+            });
+        }
+
+        /// <summary>
+        /// Tracks information about a write stream for test verification.
+        /// </summary>
+        public class WriteStreamInfo
+        {
+            public string Name { get; }
+            public WriteStream.Types.Type Type { get; }
+            public byte[]? SchemaBytes { get; set; }
+            public List<byte[]> RecordBatches { get; } = new();
+            public bool Finalized { get; set; }
+
+            public WriteStreamInfo(string name, WriteStream.Types.Type type)
+            {
+                Name = name;
+                Type = type;
+            }
+        }
+    }
+}

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryWriteService.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/MockBigQueryWriteService.cs
@@ -81,7 +81,25 @@ namespace AdbcDrivers.BigQuery.MockServer
 
                         if (request.ArrowRows.Rows?.SerializedRecordBatch != null)
                         {
-                            streamInfo.RecordBatches.Add(request.ArrowRows.Rows.SerializedRecordBatch.ToByteArray());
+                            byte[] batchBytes = request.ArrowRows.Rows.SerializedRecordBatch.ToByteArray();
+                            streamInfo.RecordBatches.Add(batchBytes);
+
+                            // Deserialize to count actual rows
+                            try
+                            {
+                                using var stream = new System.IO.MemoryStream(batchBytes);
+                                using var reader = new Apache.Arrow.Ipc.ArrowStreamReader(stream);
+                                var batch = reader.ReadNextRecordBatch();
+                                if (batch != null)
+                                {
+                                    streamInfo.RowCount += batch.Length;
+                                }
+                            }
+                            catch
+                            {
+                                // If deserialization fails, fall back to counting batches
+                                streamInfo.RowCount++;
+                            }
                         }
                     }
                 }
@@ -108,7 +126,7 @@ namespace AdbcDrivers.BigQuery.MockServer
 
             return Task.FromResult(new FinalizeWriteStreamResponse
             {
-                RowCount = _streams.TryGetValue(request.Name, out var info) ? info.RecordBatches.Count : 0
+                RowCount = _streams.TryGetValue(request.Name, out var info) ? info.RowCount : 0
             });
         }
 
@@ -134,6 +152,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             public WriteStream.Types.Type Type { get; }
             public byte[]? SchemaBytes { get; set; }
             public List<byte[]> RecordBatches { get; } = new();
+            public long RowCount { get; set; }
             public bool Finalized { get; set; }
 
             public WriteStreamInfo(string name, WriteStream.Types.Type type)

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/BulkIngestTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/BulkIngestTests.cs
@@ -37,7 +37,7 @@ namespace AdbcDrivers.BigQuery.Tests
         private readonly BigQueryTestConfiguration _testConfiguration;
         private readonly List<BigQueryTestEnvironment> _environments;
         private readonly ITestOutputHelper? _outputHelper;
-        private readonly List<(AdbcConnection connection, string catalog, string dataset, string table)> _tablesToCleanup = new();
+        private readonly List<(BigQueryTestEnvironment environment, string catalog, string dataset, string table)> _tablesToCleanup = new();
 
         public BulkIngestTests(ITestOutputHelper? outputHelper)
         {
@@ -50,10 +50,11 @@ namespace AdbcDrivers.BigQuery.Tests
 
         public void Dispose()
         {
-            foreach (var (connection, catalog, dataset, table) in _tablesToCleanup)
+            foreach (var (environment, catalog, dataset, table) in _tablesToCleanup)
             {
                 try
                 {
+                    using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                     using AdbcStatement stmt = connection.CreateStatement();
                     stmt.SqlQuery = $"DROP TABLE IF EXISTS `{catalog}.{dataset}.{table}`";
                     stmt.ExecuteUpdate();
@@ -78,9 +79,9 @@ namespace AdbcDrivers.BigQuery.Tests
             stmt.ExecuteUpdate();
         }
 
-        private void RegisterCleanup(AdbcConnection connection, string catalog, string dataset, string tableName)
+        private void RegisterCleanup(BigQueryTestEnvironment environment, string catalog, string dataset, string tableName)
         {
-            _tablesToCleanup.Add((connection, catalog, dataset, tableName));
+            _tablesToCleanup.Add((environment, catalog, dataset, tableName));
         }
 
         private static RecordBatch CreateSimpleBatch(int rowCount = 3)
@@ -139,7 +140,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 RecordBatch batch = CreateSimpleBatch(3);
 
@@ -167,7 +168,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 // First, create the table with initial data
                 RecordBatch batch1 = CreateSimpleBatch(2);
@@ -204,7 +205,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 // CreateAppend should create the table since it doesn't exist
                 RecordBatch batch1 = CreateSimpleBatch(2);
@@ -240,7 +241,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 // Create the table first
                 RecordBatch batch = CreateSimpleBatch(1);
@@ -293,7 +294,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 // Create with 5 rows
                 RecordBatch batch1 = CreateSimpleBatch(5);
@@ -330,7 +331,7 @@ namespace AdbcDrivers.BigQuery.Tests
 
                 using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
                 EnsureTableDropped(connection, catalog, dataset, tableName);
-                RegisterCleanup(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
 
                 RecordBatch batch1 = CreateSimpleBatch(2);
                 RecordBatch batch2 = CreateSimpleBatch(3);
@@ -365,6 +366,64 @@ namespace AdbcDrivers.BigQuery.Tests
                         "temp_table",
                         BulkIngestMode.Create,
                         isTemporary: true));
+            }
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestTemporalTypes()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("temporal");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
+
+                // Create a batch with temporal types that require normalization.
+                // Time32 (second) and Timestamp (nanosecond) both need conversion
+                // to microsecond precision for BigQuery.
+                var time32Builder = new Time32Array.Builder(TimeUnit.Second);
+                time32Builder.Append(3661); // 1h 1m 1s
+                time32Builder.Append(7200); // 2h
+                time32Builder.AppendNull();
+
+                var timestampBuilder = new TimestampArray.Builder(new TimestampType(TimeUnit.Nanosecond, "UTC"));
+                timestampBuilder.Append(new DateTimeOffset(2024, 6, 15, 12, 30, 45, TimeSpan.Zero));
+                timestampBuilder.Append(new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero));
+                timestampBuilder.AppendNull();
+
+                var idBuilder = new Int64Array.Builder();
+                idBuilder.Append(1);
+                idBuilder.Append(2);
+                idBuilder.Append(3);
+
+                var schema = new Schema(new[]
+                {
+                    new Field("id", Int64Type.Default, nullable: false),
+                    new Field("time_val", new Time32Type(TimeUnit.Second), nullable: true),
+                    new Field("ts_val", new TimestampType(TimeUnit.Nanosecond, "UTC"), nullable: true),
+                }, null);
+
+                var batch = new RecordBatch(schema, new IArrowArray[]
+                {
+                    idBuilder.Build(),
+                    time32Builder.Build(),
+                    timestampBuilder.Build(),
+                }, 3);
+
+                using AdbcStatement statement = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false);
+                statement.Bind(batch, batch.Schema);
+                UpdateResult result = statement.ExecuteUpdate();
+
+                Assert.Equal(3, result.AffectedRows);
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(3, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestTemporalTypes: inserted {result.AffectedRows} rows with temporal types into {catalog}.{dataset}.{tableName}");
             }
         }
 

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/BulkIngestTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/BulkIngestTests.cs
@@ -1,0 +1,396 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.BigQuery.Tests
+{
+    /// <summary>
+    /// Tests for bulk ingestion using the BigQuery Storage Write API.
+    /// Requires a live BigQuery connection configured via BIGQUERY_TEST_CONFIG_FILE.
+    /// Each test creates and cleans up its own table using catalog/dataset from the config.
+    /// </summary>
+    public class BulkIngestTests : IDisposable
+    {
+        private readonly BigQueryTestConfiguration _testConfiguration;
+        private readonly List<BigQueryTestEnvironment> _environments;
+        private readonly ITestOutputHelper? _outputHelper;
+        private readonly List<(AdbcConnection connection, string catalog, string dataset, string table)> _tablesToCleanup = new();
+
+        public BulkIngestTests(ITestOutputHelper? outputHelper)
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(BigQueryTestingUtils.BIGQUERY_TEST_CONFIG_VARIABLE));
+
+            _testConfiguration = MultiEnvironmentTestUtils.LoadMultiEnvironmentTestConfiguration<BigQueryTestConfiguration>(BigQueryTestingUtils.BIGQUERY_TEST_CONFIG_VARIABLE);
+            _environments = MultiEnvironmentTestUtils.GetTestEnvironments<BigQueryTestEnvironment>(_testConfiguration);
+            _outputHelper = outputHelper;
+        }
+
+        public void Dispose()
+        {
+            foreach (var (connection, catalog, dataset, table) in _tablesToCleanup)
+            {
+                try
+                {
+                    using AdbcStatement stmt = connection.CreateStatement();
+                    stmt.SqlQuery = $"DROP TABLE IF EXISTS `{catalog}.{dataset}.{table}`";
+                    stmt.ExecuteUpdate();
+                    _outputHelper?.WriteLine($"Cleaned up table {catalog}.{dataset}.{table}");
+                }
+                catch (Exception ex)
+                {
+                    _outputHelper?.WriteLine($"Warning: failed to clean up table {catalog}.{dataset}.{table}: {ex.Message}");
+                }
+            }
+        }
+
+        private string UniqueTableName(string testName)
+        {
+            return $"adbc_test_{testName}_{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+        }
+
+        private void EnsureTableDropped(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            using AdbcStatement stmt = connection.CreateStatement();
+            stmt.SqlQuery = $"DROP TABLE IF EXISTS `{catalog}.{dataset}.{tableName}`";
+            stmt.ExecuteUpdate();
+        }
+
+        private void RegisterCleanup(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            _tablesToCleanup.Add((connection, catalog, dataset, tableName));
+        }
+
+        private static RecordBatch CreateSimpleBatch(int rowCount = 3)
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("id", Int64Type.Default, nullable: false),
+                new Field("name", StringType.Default, nullable: true),
+                new Field("value", DoubleType.Default, nullable: true),
+            }, null);
+
+            var idBuilder = new Int64Array.Builder();
+            var nameBuilder = new StringArray.Builder();
+            var valueBuilder = new DoubleArray.Builder();
+
+            for (int i = 0; i < rowCount; i++)
+            {
+                idBuilder.Append(i + 1);
+                nameBuilder.Append($"row_{i + 1}");
+                valueBuilder.Append((i + 1) * 1.5);
+            }
+
+            return new RecordBatch(schema, new IArrowArray[]
+            {
+                idBuilder.Build(),
+                nameBuilder.Build(),
+                valueBuilder.Build(),
+            }, rowCount);
+        }
+
+        private long CountRows(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            using AdbcStatement stmt = connection.CreateStatement();
+            stmt.SqlQuery = $"SELECT COUNT(*) AS cnt FROM `{catalog}.{dataset}.{tableName}`";
+            QueryResult result = stmt.ExecuteQuery();
+            using (result.Stream!)
+            {
+                RecordBatch? batch = result.Stream!.ReadNextRecordBatchAsync().GetAwaiter().GetResult();
+                if (batch != null)
+                {
+                    var countCol = (Int64Array)batch.Column(0);
+                    return countCol.GetValue(0)!.Value;
+                }
+            }
+            return -1;
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestCreateMode()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("create");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                RecordBatch batch = CreateSimpleBatch(3);
+
+                using AdbcStatement statement = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false);
+                statement.Bind(batch, batch.Schema);
+                UpdateResult result = statement.ExecuteUpdate();
+
+                Assert.Equal(3, result.AffectedRows);
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(3, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestCreateMode: inserted {result.AffectedRows} rows into {catalog}.{dataset}.{tableName}");
+            }
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestAppendMode()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("append");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                // First, create the table with initial data
+                RecordBatch batch1 = CreateSimpleBatch(2);
+                using (AdbcStatement stmt1 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false))
+                {
+                    stmt1.Bind(batch1, batch1.Schema);
+                    stmt1.ExecuteUpdate();
+                }
+
+                // Then append more data
+                RecordBatch batch2 = CreateSimpleBatch(3);
+                using (AdbcStatement stmt2 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Append, false))
+                {
+                    stmt2.Bind(batch2, batch2.Schema);
+                    UpdateResult result = stmt2.ExecuteUpdate();
+                    Assert.Equal(3, result.AffectedRows);
+                }
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(5, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestAppendMode: total {rowCount} rows in {catalog}.{dataset}.{tableName}");
+            }
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestCreateAppendMode()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("createappend");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                // CreateAppend should create the table since it doesn't exist
+                RecordBatch batch1 = CreateSimpleBatch(2);
+                using (AdbcStatement stmt1 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.CreateAppend, false))
+                {
+                    stmt1.Bind(batch1, batch1.Schema);
+                    stmt1.ExecuteUpdate();
+                }
+
+                // CreateAppend again should append since table now exists
+                RecordBatch batch2 = CreateSimpleBatch(3);
+                using (AdbcStatement stmt2 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.CreateAppend, false))
+                {
+                    stmt2.Bind(batch2, batch2.Schema);
+                    stmt2.ExecuteUpdate();
+                }
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(5, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestCreateAppendMode: total {rowCount} rows in {catalog}.{dataset}.{tableName}");
+            }
+        }
+
+        [SkippableFact]
+        public void BulkIngestCreateFailsIfTableExists()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("createfail");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                // Create the table first
+                RecordBatch batch = CreateSimpleBatch(1);
+                using (AdbcStatement stmt1 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false))
+                {
+                    stmt1.Bind(batch, batch.Schema);
+                    stmt1.ExecuteUpdate();
+                }
+
+                // Create again should fail
+                using AdbcStatement stmt2 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false);
+                stmt2.Bind(batch, batch.Schema);
+                AdbcException ex = Assert.Throws<AdbcException>(() => stmt2.ExecuteUpdate());
+                Assert.Equal(AdbcStatusCode.AlreadyExists, ex.Status);
+
+                _outputHelper?.WriteLine($"BulkIngestCreateFailsIfTableExists: correctly threw {ex.Status}");
+            }
+        }
+
+        [SkippableFact]
+        public void BulkIngestAppendFailsIfTableMissing()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("appendfail");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+
+                RecordBatch batch = CreateSimpleBatch(1);
+                using AdbcStatement stmt = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Append, false);
+                stmt.Bind(batch, batch.Schema);
+                AdbcException ex = Assert.Throws<AdbcException>(() => stmt.ExecuteUpdate());
+                Assert.Equal(AdbcStatusCode.NotFound, ex.Status);
+
+                _outputHelper?.WriteLine($"BulkIngestAppendFailsIfTableMissing: correctly threw {ex.Status}");
+            }
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestReplaceMode()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("replace");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                // Create with 5 rows
+                RecordBatch batch1 = CreateSimpleBatch(5);
+                using (AdbcStatement stmt1 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false))
+                {
+                    stmt1.Bind(batch1, batch1.Schema);
+                    stmt1.ExecuteUpdate();
+                }
+
+                // Replace with 2 rows
+                RecordBatch batch2 = CreateSimpleBatch(2);
+                using (AdbcStatement stmt2 = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Replace, false))
+                {
+                    stmt2.Bind(batch2, batch2.Schema);
+                    UpdateResult result = stmt2.ExecuteUpdate();
+                    Assert.Equal(2, result.AffectedRows);
+                }
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(2, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestReplaceMode: replaced with {rowCount} rows in {catalog}.{dataset}.{tableName}");
+            }
+        }
+
+        [SkippableFact]
+        public void CanBulkIngestWithBindStream()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("bindstream");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(connection, catalog, dataset, tableName);
+
+                RecordBatch batch1 = CreateSimpleBatch(2);
+                RecordBatch batch2 = CreateSimpleBatch(3);
+
+                // Use BindStream with multiple batches
+                var stream = new TestArrowArrayStream(batch1.Schema, new[] { batch1, batch2 });
+
+                using AdbcStatement stmt = connection.BulkIngest(catalog, dataset, tableName, BulkIngestMode.Create, false);
+                stmt.BindStream(stream);
+                UpdateResult result = stmt.ExecuteUpdate();
+
+                Assert.Equal(5, result.AffectedRows);
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(5, rowCount);
+
+                _outputHelper?.WriteLine($"CanBulkIngestWithBindStream: inserted {result.AffectedRows} rows via stream");
+            }
+        }
+
+        [SkippableFact]
+        public void BulkIngestRejectsTemporaryTable()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+
+                Assert.Throws<AdbcException>(() =>
+                    connection.BulkIngest(
+                        environment.Metadata.Catalog,
+                        environment.Metadata.Schema,
+                        "temp_table",
+                        BulkIngestMode.Create,
+                        isTemporary: true));
+            }
+        }
+
+        /// <summary>
+        /// A simple IArrowArrayStream that yields a fixed set of record batches.
+        /// </summary>
+        private class TestArrowArrayStream : IArrowArrayStream
+        {
+            private readonly Queue<RecordBatch> _batches;
+
+            public TestArrowArrayStream(Schema schema, IEnumerable<RecordBatch> batches)
+            {
+                Schema = schema;
+                _batches = new Queue<RecordBatch>(batches);
+            }
+
+            public Schema Schema { get; }
+
+            public ValueTask<RecordBatch?> ReadNextRecordBatchAsync(System.Threading.CancellationToken cancellationToken = default)
+            {
+                if (_batches.Count > 0)
+                    return new ValueTask<RecordBatch?>(_batches.Dequeue());
+                return new ValueTask<RecordBatch?>((RecordBatch?)null);
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/MockServerTests.cs
@@ -21,6 +21,7 @@ using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Types;
 using AdbcDrivers.BigQuery.MockServer;
+using Google.Cloud.BigQuery.Storage.V1;
 using Xunit;
 
 namespace AdbcDrivers.BigQuery.Tests.MockServer
@@ -88,6 +89,74 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
                 var column = Assert.IsType<Int64Array>(resultBatch.Column(0));
                 Assert.Equal(42L, column.GetValue(0));
             }
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task CanBulkIngestAppendToTable()
+        {
+            using var mockServer = new BigQueryMockServer();
+
+            string projectId = "mock-project";
+            string datasetId = "test_dataset";
+            string tableId = "test_table";
+
+            var parameters = new Dictionary<string, string>
+            {
+                { BigQueryParameters.ProjectId, projectId },
+                { BigQueryParameters.AuthenticationType, BigQueryConstants.MockAuthenticationType },
+                { BigQueryParameters.TestRestEndpoint, mockServer.RestEndpoint },
+                { BigQueryParameters.TestStorageEndpoint, mockServer.GrpcEndpoint },
+            };
+
+            using var driver = new BigQueryDriver();
+            using AdbcDatabase database = driver.Open(parameters);
+            using AdbcConnection connection = database.Connect(new Dictionary<string, string>());
+
+            // Create test data
+            var schema = new Schema(new[]
+            {
+                new Field("id", Int64Type.Default, nullable: false),
+                new Field("name", StringType.Default, nullable: true),
+            }, null);
+
+            var idBuilder = new Int64Array.Builder();
+            idBuilder.Append(1);
+            idBuilder.Append(2);
+            idBuilder.Append(3);
+
+            var nameBuilder = new StringArray.Builder();
+            nameBuilder.Append("Alice");
+            nameBuilder.Append("Bob");
+            nameBuilder.Append("Charlie");
+
+            var batch = new RecordBatch(schema, new IArrowArray[]
+            {
+                idBuilder.Build(),
+                nameBuilder.Build()
+            }, 3);
+
+            // Use BulkIngest with CreateAppend mode (creates table if missing)
+            using AdbcStatement statement = connection.BulkIngest(projectId, datasetId, tableId, BulkIngestMode.CreateAppend, false);
+            statement.Bind(batch, schema);
+
+            UpdateResult result = statement.ExecuteUpdate();
+
+            // Verify rows were reported
+            Assert.Equal(3, result.AffectedRows);
+
+            // Verify the mock server received the data
+            Assert.Single(mockServer.WriteService.Streams);
+            var writeStream = Assert.Single(mockServer.WriteService.Streams.Values);
+            Assert.Equal(WriteStream.Types.Type.Pending, writeStream.Type);
+            Assert.True(writeStream.Finalized, "Write stream should have been finalized");
+            Assert.NotNull(writeStream.SchemaBytes);
+            Assert.Single(writeStream.RecordBatches);
+
+            // Verify the stream was committed
+            Assert.Single(mockServer.WriteService.CommittedStreams);
+
+            // Verify the table was created in the REST API
+            // (CreateAppend mode should create it since it didn't exist)
         }
     }
 }

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/NormalizationTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/NormalizationTests.cs
@@ -1,0 +1,332 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace AdbcDrivers.BigQuery.Tests
+{
+    /// <summary>
+    /// Unit tests for Arrow type normalization in BigQueryBulkIngest.
+    /// BigQuery requires microsecond precision for all time/timestamp types.
+    /// </summary>
+    public class NormalizationTests
+    {
+        #region NormalizeSchema tests
+
+        [Fact]
+        public void NormalizeSchema_NoTemporalFields_ReturnsSameSchema()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("id", Int64Type.Default, nullable: false),
+                new Field("name", StringType.Default, nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.Same(schema, result);
+        }
+
+        [Fact]
+        public void NormalizeSchema_Time32Second_ConvertedToTime64Microsecond()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("t", new Time32Type(TimeUnit.Second), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.IsType<Time64Type>(result.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, ((Time64Type)result.FieldsList[0].DataType).Unit);
+        }
+
+        [Fact]
+        public void NormalizeSchema_Time32Millisecond_ConvertedToTime64Microsecond()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("t", new Time32Type(TimeUnit.Millisecond), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.IsType<Time64Type>(result.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, ((Time64Type)result.FieldsList[0].DataType).Unit);
+        }
+
+        [Fact]
+        public void NormalizeSchema_Time64Nanosecond_ConvertedToMicrosecond()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("t", new Time64Type(TimeUnit.Nanosecond), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.IsType<Time64Type>(result.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, ((Time64Type)result.FieldsList[0].DataType).Unit);
+        }
+
+        [Fact]
+        public void NormalizeSchema_Time64Microsecond_Unchanged()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("t", new Time64Type(TimeUnit.Microsecond), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.Same(schema, result);
+        }
+
+        [Fact]
+        public void NormalizeSchema_TimestampNanosecond_ConvertedToMicrosecond()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("ts", new TimestampType(TimeUnit.Nanosecond, "UTC"), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            var tsType = Assert.IsType<TimestampType>(result.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, tsType.Unit);
+            Assert.Equal("UTC", tsType.Timezone);
+        }
+
+        [Fact]
+        public void NormalizeSchema_TimestampSecond_ConvertedToMicrosecond()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("ts", new TimestampType(TimeUnit.Second, "America/Los_Angeles"), nullable: false),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            var tsType = Assert.IsType<TimestampType>(result.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, tsType.Unit);
+            Assert.Equal("America/Los_Angeles", tsType.Timezone);
+        }
+
+        [Fact]
+        public void NormalizeSchema_TimestampMicrosecond_Unchanged()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("ts", new TimestampType(TimeUnit.Microsecond, "UTC"), nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.Same(schema, result);
+        }
+
+        [Fact]
+        public void NormalizeSchema_MixedFields_OnlyTemporalFieldsNormalized()
+        {
+            var schema = new Schema(new[]
+            {
+                new Field("id", Int64Type.Default, nullable: false),
+                new Field("t", new Time32Type(TimeUnit.Second), nullable: true),
+                new Field("name", StringType.Default, nullable: true),
+                new Field("ts", new TimestampType(TimeUnit.Nanosecond, "UTC"), nullable: true),
+                new Field("value", DoubleType.Default, nullable: true),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.IsType<Int64Type>(result.FieldsList[0].DataType);
+            Assert.IsType<Time64Type>(result.FieldsList[1].DataType);
+            Assert.Equal(TimeUnit.Microsecond, ((Time64Type)result.FieldsList[1].DataType).Unit);
+            Assert.IsType<StringType>(result.FieldsList[2].DataType);
+            var tsType = Assert.IsType<TimestampType>(result.FieldsList[3].DataType);
+            Assert.Equal(TimeUnit.Microsecond, tsType.Unit);
+            Assert.IsType<DoubleType>(result.FieldsList[4].DataType);
+        }
+
+        [Fact]
+        public void NormalizeSchema_PreservesNullabilityAndMetadata()
+        {
+            var metadata = new Dictionary<string, string> { { "key", "value" } };
+            var schema = new Schema(new[]
+            {
+                new Field("t", new Time32Type(TimeUnit.Second), nullable: false, metadata),
+            }, null);
+
+            Schema result = BigQueryBulkIngest.NormalizeSchema(schema);
+
+            Assert.False(result.FieldsList[0].IsNullable);
+            Assert.Equal("value", result.FieldsList[0].Metadata["key"]);
+        }
+
+        #endregion
+
+        #region NormalizeBatch tests
+
+        [Fact]
+        public void NormalizeBatch_NoTemporalFields_ReturnsSameBatch()
+        {
+            var batch = CreateBatchWithTypes(
+                new Field("id", Int64Type.Default, nullable: false),
+                new Field("name", StringType.Default, nullable: true));
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            Assert.Same(batch, result);
+        }
+
+        [Fact]
+        public void NormalizeBatch_Time32Second_ConvertedToMicroseconds()
+        {
+            int secondsValue = 3661; // 1h 1m 1s
+            var builder = new Time32Array.Builder(TimeUnit.Second);
+            builder.Append(secondsValue);
+            builder.AppendNull();
+
+            var schema = new Schema(new[] { new Field("t", new Time32Type(TimeUnit.Second), nullable: true) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 2);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            Assert.IsType<Time64Type>(result.Schema.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, ((Time64Type)result.Schema.FieldsList[0].DataType).Unit);
+
+            var array = (Time64Array)result.Column(0);
+            Assert.Equal(secondsValue * 1_000_000L, array.GetValue(0));
+            Assert.True(array.IsNull(1));
+        }
+
+        [Fact]
+        public void NormalizeBatch_Time32Millisecond_ConvertedToMicroseconds()
+        {
+            int msValue = 3661000; // 1h 1m 1s in ms
+            var builder = new Time32Array.Builder(TimeUnit.Millisecond);
+            builder.Append(msValue);
+
+            var schema = new Schema(new[] { new Field("t", new Time32Type(TimeUnit.Millisecond), nullable: true) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 1);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            var array = (Time64Array)result.Column(0);
+            Assert.Equal(msValue * 1_000L, array.GetValue(0));
+        }
+
+        [Fact]
+        public void NormalizeBatch_Time64Nanosecond_ConvertedToMicroseconds()
+        {
+            long nsValue = 3_661_000_000_000L; // 1h 1m 1s in ns
+            var builder = new Time64Array.Builder(TimeUnit.Nanosecond);
+            builder.Append(nsValue);
+
+            var schema = new Schema(new[] { new Field("t", new Time64Type(TimeUnit.Nanosecond), nullable: true) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 1);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            var array = (Time64Array)result.Column(0);
+            Assert.Equal(nsValue / 1_000L, array.GetValue(0));
+        }
+
+        [Fact]
+        public void NormalizeBatch_TimestampNanosecond_ConvertedToMicroseconds()
+        {
+            var ts = new DateTimeOffset(2024, 6, 15, 12, 30, 45, TimeSpan.Zero);
+            var builder = new TimestampArray.Builder(new TimestampType(TimeUnit.Nanosecond, "UTC"));
+            builder.Append(ts);
+            builder.AppendNull();
+
+            var schema = new Schema(new[] { new Field("ts", new TimestampType(TimeUnit.Nanosecond, "UTC"), nullable: true) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 2);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            var resultType = Assert.IsType<TimestampType>(result.Schema.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, resultType.Unit);
+            Assert.Equal("UTC", resultType.Timezone);
+
+            var array = (TimestampArray)result.Column(0);
+            // Verify the timestamp round-trips correctly
+            Assert.Equal(ts, array.GetTimestamp(0));
+            Assert.True(array.IsNull(1));
+        }
+
+        [Fact]
+        public void NormalizeBatch_TimestampWithoutTimezone_PreservesNullTimezone()
+        {
+            var ts = new DateTimeOffset(2024, 6, 15, 12, 30, 45, TimeSpan.Zero);
+            var builder = new TimestampArray.Builder(new TimestampType(TimeUnit.Nanosecond, (string?)null));
+            builder.Append(ts);
+
+            var schema = new Schema(new[] { new Field("ts", new TimestampType(TimeUnit.Nanosecond, (string?)null), nullable: true) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 1);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            var resultType = Assert.IsType<TimestampType>(result.Schema.FieldsList[0].DataType);
+            Assert.Equal(TimeUnit.Microsecond, resultType.Unit);
+            Assert.Null(resultType.Timezone);
+        }
+
+        [Fact]
+        public void NormalizeBatch_PreservesRowCount()
+        {
+            var builder = new Time32Array.Builder(TimeUnit.Second);
+            builder.Append(1);
+            builder.Append(2);
+            builder.Append(3);
+
+            var schema = new Schema(new[] { new Field("t", new Time32Type(TimeUnit.Second), nullable: false) }, null);
+            var batch = new RecordBatch(schema, new IArrowArray[] { builder.Build() }, 3);
+
+            RecordBatch result = BigQueryBulkIngest.NormalizeBatch(batch);
+
+            Assert.Equal(3, result.Length);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static RecordBatch CreateBatchWithTypes(params Field[] fields)
+        {
+            var schema = new Schema(fields, null);
+            var arrays = new IArrowArray[fields.Length];
+
+            for (int i = 0; i < fields.Length; i++)
+            {
+                arrays[i] = fields[i].DataType switch
+                {
+                    Int64Type => new Int64Array.Builder().Append(1).Build(),
+                    StringType => new StringArray.Builder().Append("test").Build(),
+                    _ => throw new NotSupportedException($"Test helper does not support {fields[i].DataType}")
+                };
+            }
+
+            return new RecordBatch(schema, arrays, 1);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## What's Changed

Add BulkIngest support using PENDING write streams with Arrow IPC format for efficient columnar data transfer. The implementation supports Create, Append, CreateAppend, and Replace modes with full type normalization from Arrow types to BigQuery-compatible types.

Key components:
- BigQueryBulkIngest.cs: Core write pipeline using CreateWriteStream, AppendRows (bidi gRPC streaming), FinalizeWriteStream, and BatchCommitWriteStreams for atomic commits
- BigQueryConnection.cs: BulkIngest() overloads and ProjectId property
- BigQueryStatement.cs: Bind/BindStream, ingest routing, write client creation with test endpoint support

Also adds:
- Mock gRPC write service for unit testing bulk ingestion
- Mock server table CRUD REST routes (with gzip decompression)
- Mock server test for bulk ingest append flow
- 8 live server integration tests covering all ingest modes, error cases, BindStream, and temporary table rejection