### PR TITLE
feat(go): return query statistics as schema metadata

### DIFF
--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -134,7 +134,7 @@ func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, e
 	return arrowIterator, js, totalRows, nil
 }
 
-func ipcReaderFromArrowIterator(arrowIterator bigquery.ArrowIterator, alloc memory.Allocator) (*ipc.Reader, *arrow.Schema, error) {
+func ipcReaderFromArrowIterator(arrowIterator bigquery.ArrowIterator, jobStatistics *bigquery.JobStatistics, alloc memory.Allocator) (*ipc.Reader, *arrow.Schema, error) {
 	arrowItReader := bigquery.NewArrowIteratorReader(arrowIterator)
 	rdr, err := ipc.NewReader(arrowItReader, ipc.WithAllocator(alloc))
 
@@ -149,7 +149,12 @@ func ipcReaderFromArrowIterator(arrowIterator bigquery.ArrowIterator, alloc memo
 	if err != nil {
 		return nil, nil, err
 	}
-	return rdr, arrow.NewSchema(fields, nil), nil
+
+	metadata, err := metadataFromJobStatistics(jobStatistics)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rdr, arrow.NewSchema(fields, metadata), nil
 }
 
 func getQueryParameter(values arrow.RecordBatch, row int, parameterMode string) ([]bigquery.QueryParameter, error) {
@@ -170,11 +175,16 @@ func getQueryParameter(values arrow.RecordBatch, row int, parameterMode string) 
 }
 
 func makeDryRunReader(js *bigquery.JobStatus) (array.RecordReader, error) {
+	metadata, err := metadataFromJobStatistics(js.Statistics)
+	if err != nil {
+		return nil, err
+	}
+
 	statistics, ok := js.Statistics.Details.(*bigquery.QueryStatistics)
 	var schema *arrow.Schema
 	if !ok {
 		// No schema, return an empty schema
-		schema = arrow.NewSchema([]arrow.Field{}, nil)
+		schema = arrow.NewSchema([]arrow.Field{}, metadata)
 	} else {
 		bqSchema := statistics.Schema
 		fields := make([]arrow.Field, len(bqSchema))
@@ -185,7 +195,7 @@ func makeDryRunReader(js *bigquery.JobStatus) (array.RecordReader, error) {
 				return nil, err
 			}
 		}
-		schema = arrow.NewSchema(fields, nil)
+		schema = arrow.NewSchema(fields, metadata)
 	}
 	rdr, _ := array.NewRecordReader(schema, []arrow.RecordBatch{})
 	return rdr, nil
@@ -204,7 +214,7 @@ func runPlainQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Que
 		return rdr, totalRows, nil
 	}
 
-	rdr, schema, err := ipcReaderFromArrowIterator(arrowIterator, alloc)
+	rdr, schema, err := ipcReaderFromArrowIterator(arrowIterator, jobStatus.Statistics, alloc)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -270,7 +280,7 @@ func queryRecordWithSchemaCallback(ctx context.Context, logger *slog.Logger, gro
 			continue
 		}
 		totalRows = rows
-		rdr, schema, err := ipcReaderFromArrowIterator(arrowIterator, alloc)
+		rdr, schema, err := ipcReaderFromArrowIterator(arrowIterator, jobStatus.Statistics, alloc)
 		if err != nil {
 			return -1, err
 		}

--- a/go/record_reader_test.go
+++ b/go/record_reader_test.go
@@ -23,42 +23,147 @@
 package bigquery
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmptyArrowIteratorNext(t *testing.T) {
 	iter := emptyArrowIterator{}
 	res, err := iter.Next()
 
-	if res != nil {
-		t.Errorf("Expected the result from Next to be nil, but got %v", res)
-	}
-	if err == nil {
-		t.Errorf("Expected an error from Next, but got nil")
-	}
+	require.Nil(t, res)
+	require.Error(t, err)
 }
 
 func TestEmptyArrowIteratorSchema(t *testing.T) {
 	iter := emptyArrowIterator{}
 	schema := iter.Schema()
 
-	if len(schema) > 0 {
-		t.Errorf("Expected an empty schema, but got %d", len(schema))
-	}
+	require.Empty(t, schema)
 }
 
 func TestEmptyArrowIteratorSerializedArrowSchema(t *testing.T) {
 	iter := emptyArrowIterator{}
-	bytes := iter.SerializedArrowSchema()
+	serializedSchema := iter.SerializedArrowSchema()
 
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	rdr, schema, _ := ipcReaderFromArrowIterator(iter, alloc)
-	if len(schema.Fields()) > 0 {
-		t.Errorf("Expected an empty schema, but got %d bytes", len(bytes))
-	}
-	if len(rdr.Schema().Fields()) > 0 {
-		t.Errorf("Expected an empty schema, but got %d bytes", len(bytes))
+	rdr, schema, err := ipcReaderFromArrowIterator(iter, nil, alloc)
+	require.NoError(t, err)
+	defer rdr.Release()
+	require.Empty(t, schema.Fields(), "serialized schema had %d bytes", len(serializedSchema))
+	require.Empty(t, rdr.Schema().Fields(), "serialized schema had %d bytes", len(serializedSchema))
+}
+
+func TestMetadataFromJobStatistics(t *testing.T) {
+	stats := sampleJobStatistics()
+
+	md, err := metadataFromJobStatistics(stats)
+	require.NoError(t, err)
+	metadata := md.ToMap()
+
+	assert.Equal(t, "2026-01-02T03:04:05.000000006Z", metadata["BIGQUERY:Statistics:CreationTime"])
+	assert.Equal(t, "1024", metadata["BIGQUERY:Statistics:TotalBytesProcessed"])
+	assert.Equal(t, "2000000", metadata["BIGQUERY:Statistics:TotalSlotDuration"])
+	assert.Equal(t, "5000000", metadata["BIGQUERY:Statistics:FinalExecutionDuration"])
+	assert.Equal(t, "ENTERPRISE", metadata["BIGQUERY:Statistics:Edition"])
+	assert.Equal(t, "0.75", metadata["BIGQUERY:Statistics:CompletionRatio"])
+	assert.Equal(t, "3", metadata["BIGQUERY:Statistics:Query:BillingTier"])
+	assert.Equal(t, "true", metadata["BIGQUERY:Statistics:Query:CacheHit"])
+	assert.Equal(t, "SELECT", metadata["BIGQUERY:Statistics:Query:StatementType"])
+	assert.Equal(t, "2048", metadata["BIGQUERY:Statistics:Query:TotalBytesBilled"])
+	assert.Equal(t, "4096", metadata["BIGQUERY:Statistics:Query:TotalBytesProcessed"])
+	assert.Equal(t, "PRECISE", metadata["BIGQUERY:Statistics:Query:TotalBytesProcessedAccuracy"])
+	assert.Equal(t, "6", metadata["BIGQUERY:Statistics:Query:NumDMLAffectedRows"])
+	assert.Equal(t, "33", metadata["BIGQUERY:Statistics:Query:SlotMillis"])
+	assert.Equal(t, "CREATE_TABLE", metadata["BIGQUERY:Statistics:Query:DDLOperationPerformed"])
+
+	var reservationUsage []bigquery.ReservationUsage
+	require.NoError(t, json.Unmarshal([]byte(metadata["BIGQUERY:Statistics:ReservationUsage"]), &reservationUsage))
+	require.Len(t, reservationUsage, 1)
+	assert.Equal(t, "primary", reservationUsage[0].Name)
+	assert.Equal(t, int64(12), reservationUsage[0].SlotMillis)
+
+	var dmlStats bigquery.DMLStatistics
+	require.NoError(t, json.Unmarshal([]byte(metadata["BIGQUERY:Statistics:Query:DMLStats"]), &dmlStats))
+	assert.Equal(t, int64(1), dmlStats.InsertedRowCount)
+	assert.Equal(t, int64(2), dmlStats.DeletedRowCount)
+	assert.Equal(t, int64(3), dmlStats.UpdatedRowCount)
+
+	var exportStats bigquery.ExportDataStatistics
+	require.NoError(t, json.Unmarshal([]byte(metadata["BIGQUERY:Statistics:Query:ExportDataStatistics"]), &exportStats))
+	assert.Equal(t, int64(4), exportStats.FileCount)
+	assert.Equal(t, int64(5), exportStats.RowCount)
+
+	assert.NotContains(t, metadata, "BIGQUERY:Statistics:Query:QueryPlan")
+	assert.NotContains(t, metadata, "BIGQUERY:Statistics:Query:Timeline")
+	assert.NotContains(t, metadata, "BIGQUERY:Statistics:Query:ReferencedTables")
+	assert.NotContains(t, metadata, "BIGQUERY:Statistics:Query:Schema")
+}
+
+func TestIpcReaderFromArrowIteratorAttachesJobStatisticsMetadata(t *testing.T) {
+	iter := emptyArrowIterator{}
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	rdr, schema, err := ipcReaderFromArrowIterator(iter, sampleJobStatistics(), alloc)
+	require.NoError(t, err)
+	defer rdr.Release()
+
+	metadata := schema.Metadata().ToMap()
+	assert.Equal(t, "3", metadata["BIGQUERY:Statistics:Query:BillingTier"])
+	assert.Equal(t, "SELECT", metadata["BIGQUERY:Statistics:Query:StatementType"])
+}
+
+func TestMakeDryRunReaderAttachesJobStatisticsMetadata(t *testing.T) {
+	rdr, err := makeDryRunReader(&bigquery.JobStatus{
+		Statistics: sampleJobStatistics(),
+	})
+	require.NoError(t, err)
+	defer rdr.Release()
+
+	metadata := rdr.Schema().Metadata().ToMap()
+	assert.Equal(t, "3", metadata["BIGQUERY:Statistics:Query:BillingTier"])
+	assert.Equal(t, "SELECT", metadata["BIGQUERY:Statistics:Query:StatementType"])
+}
+
+func sampleJobStatistics() *bigquery.JobStatistics {
+	return &bigquery.JobStatistics{
+		CreationTime:           time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC),
+		StartTime:              time.Date(2026, 1, 2, 3, 4, 6, 7, time.UTC),
+		EndTime:                time.Date(2026, 1, 2, 3, 4, 7, 8, time.UTC),
+		TotalBytesProcessed:    1024,
+		TotalSlotDuration:      2 * time.Millisecond,
+		ReservationUsage:       []*bigquery.ReservationUsage{{Name: "primary", SlotMillis: 12}},
+		ReservationID:          "reservation-id",
+		NumChildJobs:           2,
+		ParentJobID:            "parent-job-id",
+		TransactionInfo:        &bigquery.TransactionInfo{TransactionID: "transaction-id"},
+		SessionInfo:            &bigquery.SessionInfo{SessionID: "session-id"},
+		FinalExecutionDuration: 5 * time.Millisecond,
+		Edition:                bigquery.ReservationEditionEnterprise,
+		CompletionRatio:        0.75,
+		Details: &bigquery.QueryStatistics{
+			BillingTier:                   3,
+			CacheHit:                      true,
+			StatementType:                 "SELECT",
+			TotalBytesBilled:              2048,
+			TotalBytesProcessed:           4096,
+			TotalBytesProcessedAccuracy:   "PRECISE",
+			QueryPlan:                     []*bigquery.ExplainQueryStage{{ID: 1, Name: "omitted"}},
+			NumDMLAffectedRows:            6,
+			DMLStats:                      &bigquery.DMLStatistics{InsertedRowCount: 1, DeletedRowCount: 2, UpdatedRowCount: 3},
+			Timeline:                      []*bigquery.QueryTimelineSample{{Elapsed: time.Millisecond}},
+			ReferencedTables:              []*bigquery.Table{{ProjectID: "project", DatasetID: "dataset", TableID: "table"}},
+			Schema:                        bigquery.Schema{&bigquery.FieldSchema{Name: "omitted", Type: bigquery.StringFieldType}},
+			SlotMillis:                    33,
+			UndeclaredQueryParameterNames: []string{"parameter"},
+			DDLOperationPerformed:         "CREATE_TABLE",
+			ExportDataStatistics:          &bigquery.ExportDataStatistics{FileCount: 4, RowCount: 5},
+		},
 	}
 }

--- a/go/statement.go
+++ b/go/statement.go
@@ -459,7 +459,11 @@ func (st *statement) ExecuteSchema(ctx context.Context) (*arrow.Schema, error) {
 		fields[i] = f
 	}
 
-	return arrow.NewSchema(fields, nil), nil
+	metadata, err := metadataFromJobStatistics(status.Statistics)
+	if err != nil {
+		return nil, err
+	}
+	return arrow.NewSchema(fields, metadata), nil
 }
 
 // Prepare turns this statement into a prepared statement to be executed

--- a/go/statistics_metadata.go
+++ b/go/statistics_metadata.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"encoding/json"
+	"reflect"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+func metadataFromQueryStatistics(metadata map[string]string, queryStatistics *bigquery.QueryStatistics) error {
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:BIEngineStatistics", queryStatistics.BIEngineStatistics); err != nil {
+		return err
+	}
+	addIntMetadata(metadata, "BIGQUERY:Statistics:Query:BillingTier", queryStatistics.BillingTier)
+	addBoolMetadata(metadata, "BIGQUERY:Statistics:Query:CacheHit", queryStatistics.CacheHit)
+	addStringMetadata(metadata, "BIGQUERY:Statistics:Query:StatementType", queryStatistics.StatementType)
+	addIntMetadata(metadata, "BIGQUERY:Statistics:Query:TotalBytesBilled", queryStatistics.TotalBytesBilled)
+	addIntMetadata(metadata, "BIGQUERY:Statistics:Query:TotalBytesProcessed", queryStatistics.TotalBytesProcessed)
+	addStringMetadata(metadata, "BIGQUERY:Statistics:Query:TotalBytesProcessedAccuracy", queryStatistics.TotalBytesProcessedAccuracy)
+	addIntMetadata(metadata, "BIGQUERY:Statistics:Query:NumDMLAffectedRows", queryStatistics.NumDMLAffectedRows)
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:DMLStats", queryStatistics.DMLStats); err != nil {
+		return err
+	}
+	addIntMetadata(metadata, "BIGQUERY:Statistics:Query:SlotMillis", queryStatistics.SlotMillis)
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:UndeclaredQueryParameterNames", queryStatistics.UndeclaredQueryParameterNames); err != nil {
+		return err
+	}
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:DDLTargetTable", queryStatistics.DDLTargetTable); err != nil {
+		return err
+	}
+	addStringMetadata(metadata, "BIGQUERY:Statistics:Query:DDLOperationPerformed", queryStatistics.DDLOperationPerformed)
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:DDLTargetRoutine", queryStatistics.DDLTargetRoutine); err != nil {
+		return err
+	}
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:ExportDataStatistics", queryStatistics.ExportDataStatistics); err != nil {
+		return err
+	}
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:Query:PerformanceInsights", queryStatistics.PerformanceInsights); err != nil {
+		return err
+	}
+	return nil
+}
+
+func metadataFromJobStatistics(stats *bigquery.JobStatistics) (*arrow.Metadata, error) {
+	if stats == nil {
+		return nil, nil
+	}
+
+	metadata := make(map[string]string)
+	addTimeMetadata(metadata, "BIGQUERY:Statistics:CreationTime", stats.CreationTime)
+	addTimeMetadata(metadata, "BIGQUERY:Statistics:StartTime", stats.StartTime)
+	addTimeMetadata(metadata, "BIGQUERY:Statistics:EndTime", stats.EndTime)
+	addIntMetadata(metadata, "BIGQUERY:Statistics:TotalBytesProcessed", stats.TotalBytesProcessed)
+	addDurationMetadata(metadata, "BIGQUERY:Statistics:TotalSlotDuration", stats.TotalSlotDuration)
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:ReservationUsage", stats.ReservationUsage); err != nil {
+		return nil, err
+	}
+	addStringMetadata(metadata, "BIGQUERY:Statistics:ReservationID", stats.ReservationID)
+	addIntMetadata(metadata, "BIGQUERY:Statistics:NumChildJobs", stats.NumChildJobs)
+	addStringMetadata(metadata, "BIGQUERY:Statistics:ParentJobID", stats.ParentJobID)
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:ScriptStatistics", stats.ScriptStatistics); err != nil {
+		return nil, err
+	}
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:TransactionInfo", stats.TransactionInfo); err != nil {
+		return nil, err
+	}
+	if err := addJSONMetadata(metadata, "BIGQUERY:Statistics:SessionInfo", stats.SessionInfo); err != nil {
+		return nil, err
+	}
+	addDurationMetadata(metadata, "BIGQUERY:Statistics:FinalExecutionDuration", stats.FinalExecutionDuration)
+	addStringMetadata(metadata, "BIGQUERY:Statistics:Edition", string(stats.Edition))
+	addFloatMetadata(metadata, "BIGQUERY:Statistics:CompletionRatio", stats.CompletionRatio)
+
+	queryStatistics, ok := stats.Details.(*bigquery.QueryStatistics)
+	if ok && queryStatistics != nil {
+		if err := metadataFromQueryStatistics(metadata, queryStatistics); err != nil {
+			return nil, err
+		}
+	}
+	return new(arrow.MetadataFrom(metadata)), nil
+}
+
+func addTimeMetadata(metadata map[string]string, key string, value time.Time) {
+	if value.IsZero() {
+		return
+	}
+	metadata[key] = value.Format(time.RFC3339Nano)
+}
+
+func addDurationMetadata(metadata map[string]string, key string, value time.Duration) {
+	metadata[key] = strconv.FormatInt(int64(value), 10)
+}
+
+func addIntMetadata(metadata map[string]string, key string, value int64) {
+	metadata[key] = strconv.FormatInt(value, 10)
+}
+
+func addFloatMetadata(metadata map[string]string, key string, value float64) {
+	metadata[key] = strconv.FormatFloat(value, 'g', -1, 64)
+}
+
+func addBoolMetadata(metadata map[string]string, key string, value bool) {
+	metadata[key] = strconv.FormatBool(value)
+}
+
+func addStringMetadata(metadata map[string]string, key string, value string) {
+	if value == "" {
+		return
+	}
+	metadata[key] = value
+}
+
+func addJSONMetadata(metadata map[string]string, key string, value any) error {
+	if isNilOrEmpty(value) {
+		return nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	metadata[key] = string(encoded)
+	return nil
+}
+
+func isNilOrEmpty(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil() || (reflected.Kind() == reflect.Slice && reflected.Len() == 0)
+	case reflect.Array:
+		return reflected.Len() == 0
+	default:
+		return false
+	}
+}

--- a/go/validation/tests/test_statement.py
+++ b/go/validation/tests/test_statement.py
@@ -40,3 +40,7 @@ def test_dry_run(driver, conn) -> None:
         assert len(cursor.description) == 2
         assert cursor.description[0][0] == "a"
         assert cursor.description[1][0] == "b"
+
+        cursor.execute("SELECT 1 AS a, 'foobar' as b", parameters=[(1,), (2,)])
+        schema = cursor.fetchallarrow().schema
+        assert schema.metadata[b"BIGQUERY:Statistics:Query:StatementType"] == b"SELECT"


### PR DESCRIPTION
Addresses #210.

Assisted-by: GPT-5.5 <codex@openai.com>