### PR TITLE
feat(go): allow overriding the gRPC endpoint for Storage Read API

### DIFF
--- a/go/bigquery_database.go
+++ b/go/bigquery_database.go
@@ -53,11 +53,12 @@ type databaseImpl struct {
 	// projectID is the catalog
 	projectID string
 	// datasetID is the schema
-	datasetID    string
-	tableID      string
-	location     string
-	quotaProject string
-	endpoint     string
+	datasetID       string
+	tableID         string
+	location        string
+	quotaProject    string
+	endpoint        string
+	storageEndpoint string
 
 	bulkIngestMethod      string
 	bulkIngestCompression string
@@ -81,6 +82,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.ConnectionWithContext, er
 		dbSchema:                   d.datasetID,
 		location:                   d.location,
 		endpoint:                   d.endpoint,
+		storageEndpoint:            d.storageEndpoint,
 		resultRecordBufferSize:     defaultQueryResultBufferSize,
 		prefetchConcurrency:        defaultQueryPrefetchConcurrency,
 		quotaProject:               d.quotaProject,
@@ -129,6 +131,8 @@ func (d *databaseImpl) GetOption(ctx context.Context, key string) (string, error
 		return d.tableID, nil
 	case OptionStringEndpoint:
 		return d.endpoint, nil
+	case OptionStringStorageEndpoint:
+		return d.storageEndpoint, nil
 	case OptionStringImpersonateLifetime:
 		if d.impersonateLifetime == 0 {
 			// If no lifetime is set but impersonation is enabled, return the default
@@ -200,7 +204,8 @@ func (d *databaseImpl) SetOption(ctx context.Context, key string, value string) 
 			OptionValueAuthTypeJSONCredentialFile,
 			OptionValueAuthTypeJSONCredentialString,
 			OptionValueAuthTypeUserAuthentication,
-			OptionValueAuthTypeAppDefaultCredentials:
+			OptionValueAuthTypeAppDefaultCredentials,
+			OptionValueAuthTypeAnonymous:
 			d.authType = value
 		default:
 			return adbc.Error{
@@ -258,6 +263,8 @@ func (d *databaseImpl) SetOption(ctx context.Context, key string, value string) 
 		d.tableID = value
 	case OptionStringEndpoint:
 		d.endpoint = value
+	case OptionStringStorageEndpoint:
+		d.storageEndpoint = value
 	case OptionStringLocation:
 		d.location = value
 	case OptionStringBulkIngestMethod:

--- a/go/connection.go
+++ b/go/connection.go
@@ -45,6 +45,8 @@ import (
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type connectionImpl struct {
@@ -72,7 +74,8 @@ type connectionImpl struct {
 	// tableID is the default table for statement
 	tableID string
 	// endpoint is the custom BigQuery API endpoint
-	endpoint string
+	endpoint        string
+	storageEndpoint string
 
 	sessionID *string
 
@@ -774,6 +777,9 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		c.Logger.Debug("Using Application Default Credentials (ADC)", "authType", c.authType)
 		// Use Application Default Credentials (default behavior)
 		// No additional options needed - ADC is used by default
+	case OptionValueAuthTypeAnonymous:
+		c.Logger.Debug("Using anonymous authentication")
+		authOptions = append(authOptions, option.WithoutAuthentication())
 	default:
 		return adbc.Error{
 			Code: adbc.StatusInvalidArgument,
@@ -836,7 +842,12 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	}
 
 	// Use original authOptions without custom endpoint for Storage Read API
-	err = client.EnableStorageReadClient(ctx, authOptions...)
+	storageAuthOptions := authOptions
+	if c.storageEndpoint != "" {
+		storageAuthOptions = append(storageAuthOptions, option.WithEndpoint(c.storageEndpoint))
+		storageAuthOptions = append(storageAuthOptions, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
+	}
+	err = client.EnableStorageReadClient(ctx, storageAuthOptions...)
 	if err != nil {
 		return errToAdbcErr(adbc.StatusIO, err, "enable storage read client")
 	}

--- a/go/connection.go
+++ b/go/connection.go
@@ -845,6 +845,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	storageAuthOptions := authOptions
 	if c.storageEndpoint != "" {
 		storageAuthOptions = append(storageAuthOptions, option.WithEndpoint(c.storageEndpoint))
+		// assume insecure since the purpose of this is to use the emulator, which does not use TLS
 		storageAuthOptions = append(storageAuthOptions, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 	err = client.EnableStorageReadClient(ctx, storageAuthOptions...)

--- a/go/docs/bigquery.md
+++ b/go/docs/bigquery.md
@@ -91,6 +91,10 @@ Components:
 Reserved characters in URI elements must be URI-encoded. For example, `@` becomes `%40`.
 :::
 
+:::{note}
+Overriding the endpoint via the URI will lead to HTTPS always being assumed.
+:::
+
 Examples:
 
 - `bigquery:///my-project-123` (uses Application Default Credentials)

--- a/go/driver.go
+++ b/go/driver.go
@@ -38,17 +38,19 @@ const (
 	OptionStringAuthType = "adbc.bigquery.sql.auth_type"
 	// https://pkg.go.dev/google.golang.org/api@v0.258.0/option#WithAuthCredentialsJSON
 	// https://pkg.go.dev/google.golang.org/api@v0.258.0/internal/credentialstype#CredType
-	OptionAuthCredentialsType = "bigquery.auth.credentials_type"
-	OptionStringLocation      = "adbc.bigquery.sql.location"
-	OptionStringProjectID     = "adbc.bigquery.sql.project_id"
-	OptionStringDatasetID     = "adbc.bigquery.sql.dataset_id"
-	OptionStringTableID       = "adbc.bigquery.sql.table_id"
-	OptionStringEndpoint      = "adbc.bigquery.sql.endpoint"
+	OptionAuthCredentialsType   = "bigquery.auth.credentials_type"
+	OptionStringLocation        = "adbc.bigquery.sql.location"
+	OptionStringProjectID       = "adbc.bigquery.sql.project_id"
+	OptionStringDatasetID       = "adbc.bigquery.sql.dataset_id"
+	OptionStringTableID         = "adbc.bigquery.sql.table_id"
+	OptionStringEndpoint        = "adbc.bigquery.sql.endpoint"
+	OptionStringStorageEndpoint = "adbc.bigquery.sql.storage_endpoint"
 
 	OptionValueAuthTypeDefault = "adbc.bigquery.sql.auth_type.auth_bigquery"
 
 	OptionValueAuthTypeJSONCredentialFile   = "adbc.bigquery.sql.auth_type.json_credential_file"
 	OptionValueAuthTypeJSONCredentialString = "adbc.bigquery.sql.auth_type.json_credential_string"
+	OptionValueAuthTypeAnonymous            = "adbc.bigquery.sql.auth_type.anonymous"
 	OptionStringAuthCredentials             = "adbc.bigquery.sql.auth_credentials"
 
 	OptionValueAuthTypeUserAuthentication = "adbc.bigquery.sql.auth_type.user_authentication"

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -91,14 +91,17 @@ func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, e
 		}
 	}
 
+	isSelectOrCall := false
+	stats, statsOk := js.Statistics.Details.(*bigquery.QueryStatistics)
 	if executeUpdate {
-		stats, ok := js.Statistics.Details.(*bigquery.QueryStatistics)
-		if ok {
+		if statsOk {
 			return nil, js, stats.NumDMLAffectedRows, nil
 		}
 		return nil, js, -1, nil
 	} else if query.DryRun {
 		return nil, js, js.Statistics.TotalBytesProcessed, nil
+	} else if statsOk {
+		isSelectOrCall = stats.StatementType == "SELECT" || stats.StatementType == "CALL"
 	}
 
 	// XXX: the Google SDK badness also applies here; it makes a similar
@@ -109,9 +112,14 @@ func runQuery(ctx context.Context, logger *slog.Logger, query *bigquery.Query, e
 	}
 
 	var arrowIterator bigquery.ArrowIterator
-	// If there is no schema in the row iterator, then arrow
-	// iterator should be empty (#2173)
-	if iter.TotalRows > 0 {
+	// We need to detect if this actually returned data. Originally we
+	// checked for the presence of a schema, but it turns out statements
+	// like CREATE VIEW return a schema! Then we checked if there are
+	// rows, but it turns out that bigquery-emulator returns
+	// iter.TotalRows == 0 (this is valid as per the API: the field is not
+	// _necessarily_ populated until after a call to Next). Finally we use
+	// job statistics instead
+	if isSelectOrCall {
 		// !IsAccelerated() -> failed to get Arrow stream -> we are
 		// probably lacking permissions.  readSessionUser may sound
 		// unrelated but creating a "read session" is the first step


### PR DESCRIPTION
For now we hardcode the assumption of plaintext gRPC.

Addresses #202.
