### PR TITLE
feat(csharp): implement transaction support

### DIFF
--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -54,6 +54,7 @@ namespace AdbcDrivers.BigQuery
         readonly Dictionary<string, string> properties;
         readonly HttpClient httpClient;
         private readonly object _clientTimeoutLock = new object();
+        private string? _sessionId;
         const string ClassName = nameof(BigQueryConnection);
         const string infoDriverName = "ADBC BigQuery Driver";
         const string infoVendorName = "BigQuery";
@@ -182,6 +183,12 @@ namespace AdbcDrivers.BigQuery
         internal string DriverName => infoDriverName;
 
         internal BigQueryClient? Client { get; private set; }
+
+        /// <summary>
+        /// The active BigQuery session ID when autocommit is disabled, or null when in autocommit mode.
+        /// Used by <see cref="BigQueryStatement"/> to attach queries to the active session/transaction.
+        /// </summary>
+        internal string? SessionId => _sessionId;
 
         internal GoogleCredential? Credential { get; private set; }
 
@@ -792,6 +799,61 @@ namespace AdbcDrivers.BigQuery
         internal static bool IsUnauthorizedException(Exception ex, out GoogleApiException? googleEx)
         {
             return BigQueryUtils.ContainsException(ex, out googleEx) && googleEx!.Error.Code == (int)System.Net.HttpStatusCode.Unauthorized;
+        }
+
+        /// <summary>
+        /// Executes a SQL command within the context of the active session (if any).
+        /// Used internally for transaction management (BEGIN/COMMIT/ROLLBACK) and session lifecycle.
+        /// </summary>
+        /// <param name="sql">The SQL statement to execute.</param>
+        /// <param name="createSession">If true, requests BigQuery to create a new session.</param>
+        /// <returns>The BigQueryJob for the executed command.</returns>
+        private BigQueryJob ExecuteSessionCommand(string sql, bool createSession = false)
+        {
+            if (Client == null) { Client = Open(); }
+
+            return this.TraceActivity(activity =>
+            {
+                activity?.AddConditionalTag(SemanticConventions.Db.Query.Text, sql, IsSafeToTrace);
+                if (_sessionId != null)
+                {
+                    activity?.AddBigQueryTag("session_id", _sessionId);
+                }
+                if (createSession)
+                {
+                    activity?.AddBigQueryTag("create_session", true);
+                }
+
+                QueryOptions queryOptions = new QueryOptions
+                {
+                    ConfigurationModifier = query =>
+                    {
+                        if (createSession)
+                        {
+                            query.CreateSession = true;
+                        }
+                        if (_sessionId != null)
+                        {
+                            query.ConnectionProperties ??= new List<ConnectionProperty>();
+                            query.ConnectionProperties.Add(new ConnectionProperty
+                            {
+                                Key = "session_id",
+                                Value = _sessionId,
+                            });
+                        }
+                    }
+                };
+
+                Task<BigQueryJob> func()
+                {
+                    return Client.CreateQueryJobAsync(sql, System.Array.Empty<BigQueryParameter>(), queryOptions);
+                }
+
+                BigQueryJob job = ExecuteWithRetriesAsync<BigQueryJob>(func, activity).GetAwaiter().GetResult();
+                activity?.AddBigQueryTag("job_id", job.Reference.JobId);
+                job.GetQueryResultsAsync().GetAwaiter().GetResult();
+                return job;
+            }, ClassName + "." + nameof(ExecuteSessionCommand));
         }
 
         private IArrowArray[] GetCatalogs(
@@ -1538,6 +1600,174 @@ namespace AdbcDrivers.BigQuery
             return new BigQueryInfoArrowStream(StandardSchemas.TableTypesSchema, dataArrays);
         }
 
+        /// <summary>
+        /// Gets or sets the autocommit state. When set to false, creates a BigQuery session and
+        /// begins a transaction. When set to true, commits any pending transaction and closes the session.
+        /// </summary>
+        public override bool AutoCommit
+        {
+            get => _sessionId == null;
+            set
+            {
+                this.TraceActivity(activity =>
+                {
+                    activity?.AddBigQueryTag("autocommit.target", value);
+                    if (_sessionId != null)
+                    {
+                        activity?.AddBigQueryTag("session_id", _sessionId);
+                    }
+
+                    if (value)
+                    {
+                        // Turning autocommit ON: commit pending transaction and close session
+                        if (_sessionId == null)
+                        {
+                            throw new AdbcException("Autocommit is already enabled", AdbcStatusCode.InvalidState);
+                        }
+
+                        try
+                        {
+                            ExecuteSessionCommand("COMMIT TRANSACTION");
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new AdbcException("Failed to commit transaction", AdbcStatusCode.InternalError, ex);
+                        }
+
+                        try
+                        {
+                            ExecuteSessionCommand($"CALL BQ.ABORT_SESSION('{_sessionId}')");
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new AdbcException("Failed to close session", AdbcStatusCode.InternalError, ex);
+                        }
+
+                        activity?.AddEvent("session_closed");
+                        _sessionId = null;
+                    }
+                    else
+                    {
+                        // Turning autocommit OFF: create session and begin transaction
+                        if (_sessionId != null)
+                        {
+                            throw new AdbcException("Autocommit is already disabled", AdbcStatusCode.InvalidState);
+                        }
+
+                        BigQueryJob sessionJob;
+                        try
+                        {
+                            sessionJob = ExecuteSessionCommand("SELECT 1", createSession: true);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new AdbcException("Failed to create session", AdbcStatusCode.InternalError, ex);
+                        }
+
+                        string? sessionId = sessionJob.Resource.Statistics?.SessionInfo?.SessionId;
+                        if (string.IsNullOrEmpty(sessionId))
+                        {
+                            throw new AdbcException("Could not create session: no session info in job status", AdbcStatusCode.InternalError);
+                        }
+
+                        _sessionId = sessionId;
+                        activity?.AddBigQueryTag("session_id", _sessionId);
+                        activity?.AddEvent("session_created");
+
+                        try
+                        {
+                            ExecuteSessionCommand("BEGIN TRANSACTION");
+                        }
+                        catch (Exception ex)
+                        {
+                            _sessionId = null;
+                            throw new AdbcException("Failed to begin transaction", AdbcStatusCode.InternalError, ex);
+                        }
+
+                        activity?.AddEvent("transaction_started");
+                    }
+                }, ClassName + ".set_" + nameof(AutoCommit));
+            }
+        }
+
+        /// <summary>
+        /// Commits the pending transaction and begins a new one.
+        /// Only used when autocommit is disabled.
+        /// </summary>
+        public override void Commit()
+        {
+            this.TraceActivity(activity =>
+            {
+                if (_sessionId == null)
+                {
+                    throw new AdbcException("Cannot commit when autocommit is enabled", AdbcStatusCode.InvalidState);
+                }
+
+                activity?.AddBigQueryTag("session_id", _sessionId);
+
+                try
+                {
+                    ExecuteSessionCommand("COMMIT TRANSACTION");
+                }
+                catch (Exception ex)
+                {
+                    throw new AdbcException("Failed to commit transaction", AdbcStatusCode.InternalError, ex);
+                }
+
+                activity?.AddEvent("transaction_committed");
+
+                try
+                {
+                    ExecuteSessionCommand("BEGIN TRANSACTION");
+                }
+                catch (Exception ex)
+                {
+                    throw new AdbcException("Failed to begin new transaction after commit", AdbcStatusCode.InternalError, ex);
+                }
+
+                activity?.AddEvent("transaction_started");
+            }, ClassName + "." + nameof(Commit));
+        }
+
+        /// <summary>
+        /// Rolls back the pending transaction and begins a new one.
+        /// Only used when autocommit is disabled.
+        /// </summary>
+        public override void Rollback()
+        {
+            this.TraceActivity(activity =>
+            {
+                if (_sessionId == null)
+                {
+                    throw new AdbcException("Cannot rollback when autocommit is enabled", AdbcStatusCode.InvalidState);
+                }
+
+                activity?.AddBigQueryTag("session_id", _sessionId);
+
+                try
+                {
+                    ExecuteSessionCommand("ROLLBACK TRANSACTION");
+                }
+                catch (Exception ex)
+                {
+                    throw new AdbcException("Failed to rollback transaction", AdbcStatusCode.InternalError, ex);
+                }
+
+                activity?.AddEvent("transaction_rolled_back");
+
+                try
+                {
+                    ExecuteSessionCommand("BEGIN TRANSACTION");
+                }
+                catch (Exception ex)
+                {
+                    throw new AdbcException("Failed to begin new transaction after rollback", AdbcStatusCode.InternalError, ex);
+                }
+
+                activity?.AddEvent("transaction_started");
+            }, ClassName + "." + nameof(Rollback));
+        }
+
         public override AdbcStatement CreateStatement()
         {
             if (Credential == null)
@@ -1584,6 +1814,19 @@ namespace AdbcDrivers.BigQuery
 
         public override void Dispose()
         {
+            if (_sessionId != null)
+            {
+                try
+                {
+                    ExecuteSessionCommand($"CALL BQ.ABORT_SESSION('{_sessionId}')");
+                }
+                catch
+                {
+                    // Best-effort session cleanup during disposal
+                }
+                _sessionId = null;
+            }
+
             Client?.Dispose();
             Client = null;
             this.httpClient?.Dispose();

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -1680,6 +1680,16 @@ namespace AdbcDrivers.BigQuery
                         }
                         catch (Exception ex)
                         {
+                            // Best-effort: abort the newly-created session so it doesn't leak server-side.
+                            try
+                            {
+                                ExecuteSessionCommand($"CALL BQ.ABORT_SESSION('{_sessionId}')");
+                            }
+                            catch
+                            {
+                                // Ignore cleanup errors; original exception is more important.
+                            }
+
                             _sessionId = null;
                             throw new AdbcException("Failed to begin transaction", AdbcStatusCode.InternalError, ex);
                         }

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -852,11 +852,31 @@ namespace AdbcDrivers.BigQuery
 
                 using JobCancellationContext context = new(cancellationRegistry);
                 // Cannot set destination table in jobs with DDL statements, otherwise an error will be prompted
+                // Build query options with session properties if a transaction is active
+                QueryOptions? updateQueryOptions = null;
+                string? sessionId = this.bigQueryConnection.SessionId;
+                if (sessionId != null)
+                {
+                    activity?.AddBigQueryTag("session_id", sessionId);
+                    updateQueryOptions = new QueryOptions
+                    {
+                        ConfigurationModifier = query =>
+                        {
+                            query.ConnectionProperties ??= new List<Google.Apis.Bigquery.v2.Data.ConnectionProperty>();
+                            query.ConnectionProperties.Add(new Google.Apis.Bigquery.v2.Data.ConnectionProperty
+                            {
+                                Key = "session_id",
+                                Value = sessionId,
+                            });
+                        }
+                    };
+                }
+
                 Task<BigQueryResults> getQueryResultsAsyncFunc()
                 {
                     return ExecuteCancellableJobAsync(context, activity, async (context, jobActivity) =>
                     {
-                        context.Job = await this.Client.CreateQueryJobAsync(SqlQuery, null, null, context.CancellationToken).ConfigureAwait(false);
+                        context.Job = await this.Client.CreateQueryJobAsync(SqlQuery, null, updateQueryOptions, context.CancellationToken).ConfigureAwait(false);
                         jobActivity?.AddEvent("getqueryresultsasync_started", [new("job.id", context.Job.Reference.JobId)]);
                         BigQueryResults results = await context.Job.GetQueryResultsAsync(getQueryResultsOptions, context.CancellationToken).ConfigureAwait(false);
                         jobActivity?.AddEvent("getqueryresultsasync_completed", GetJobStatistics(jobActivity, context.Job));
@@ -1093,6 +1113,24 @@ namespace AdbcDrivers.BigQuery
             if (options.AllowLargeResults == true && options.DestinationTable == null)
             {
                 options.DestinationTable = TryGetLargeDestinationTableReference(largeResultDatasetId, activity);
+            }
+
+            // Attach session connection properties when a transaction is active
+            string? sessionId = this.bigQueryConnection.SessionId;
+            if (sessionId != null)
+            {
+                activity?.AddBigQueryTag("session_id", sessionId);
+                Action<JobConfigurationQuery>? existingModifier = options.ConfigurationModifier;
+                options.ConfigurationModifier = query =>
+                {
+                    existingModifier?.Invoke(query);
+                    query.ConnectionProperties ??= new List<Google.Apis.Bigquery.v2.Data.ConnectionProperty>();
+                    query.ConnectionProperties.Add(new Google.Apis.Bigquery.v2.Data.ConnectionProperty
+                    {
+                        Key = "session_id",
+                        Value = sessionId,
+                    });
+                };
             }
 
             return options;

--- a/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.MockServer/BigQueryMockServer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO.Compression;
 using System.Net;
 using System.Threading;
@@ -43,6 +44,8 @@ namespace AdbcDrivers.BigQuery.MockServer
         private readonly CancellationTokenSource _cts = new();
         private readonly ConcurrentDictionary<string, MockJob> _jobs = new();
         private readonly ConcurrentDictionary<string, Table> _tables = new();
+        private readonly ConcurrentDictionary<string, bool> _sessions = new();
+        private readonly ConcurrentQueue<string> _executedQueries = new();
 
         /// <summary>
         /// The REST API endpoint as host:port (e.g., "127.0.0.1:12345").
@@ -55,6 +58,11 @@ namespace AdbcDrivers.BigQuery.MockServer
         /// Set this as the <c>adbc.bigquery.test.storage_endpoint</c> parameter.
         /// </summary>
         public string GrpcEndpoint { get; }
+
+        /// <summary>
+        /// Returns the list of SQL queries that were executed against this mock server, in order.
+        /// </summary>
+        public IReadOnlyList<string> ExecutedQueries => _executedQueries.ToArray();
 
         /// <summary>
         /// The mock gRPC service for configuring Storage Read API responses.
@@ -134,9 +142,50 @@ namespace AdbcDrivers.BigQuery.MockServer
             // POST /bigquery/v2/projects/{projectId}/jobs - Create a query job
             app.MapPost("/bigquery/v2/projects/{projectId}/jobs", async (HttpContext ctx, string projectId) =>
             {
-                await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
+                string body;
+                if (string.Equals(ctx.Request.Headers["Content-Encoding"].ToString(), "gzip", StringComparison.OrdinalIgnoreCase))
+                {
+                    await using var gzipStream = new GZipStream(ctx.Request.Body, CompressionMode.Decompress, leaveOpen: true);
+                    using var reader = new System.IO.StreamReader(gzipStream);
+                    body = await reader.ReadToEndAsync();
+                }
+                else
+                {
+                    body = await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
+                }
+
+                Job? jobRequest = null;
+                try
+                {
+                    jobRequest = NewtonsoftJsonSerializer.Instance.Deserialize<Job>(body);
+                }
+                catch
+                {
+                    // If deserialization fails, proceed without parsed request
+                }
 
                 string jobId = $"mock-job-{Guid.NewGuid():N}";
+                string? queryText = jobRequest?.Configuration?.Query?.Query;
+                bool createSession = jobRequest?.Configuration?.Query?.CreateSession == true;
+                string? sessionId = null;
+
+                // Check for session_id in ConnectionProperties
+                if (jobRequest?.Configuration?.Query?.ConnectionProperties != null)
+                {
+                    foreach (var prop in jobRequest.Configuration.Query.ConnectionProperties)
+                    {
+                        if (prop.Key == "session_id")
+                        {
+                            sessionId = prop.Value;
+                            break;
+                        }
+                    }
+                }
+
+                if (queryText != null)
+                {
+                    _executedQueries.Enqueue(queryText);
+                }
 
                 var mockJob = new MockJob
                 {
@@ -144,6 +193,19 @@ namespace AdbcDrivers.BigQuery.MockServer
                     ProjectId = projectId,
                     Status = "DONE",
                 };
+
+                // If CreateSession is requested, generate a new session ID
+                if (createSession)
+                {
+                    string newSessionId = $"mock-session-{Guid.NewGuid():N}";
+                    _sessions[newSessionId] = true;
+                    mockJob.SessionId = newSessionId;
+                }
+                else if (sessionId != null)
+                {
+                    mockJob.SessionId = sessionId;
+                }
+
                 _jobs[jobId] = mockJob;
 
                 var job = CreateJobResource(mockJob);
@@ -285,6 +347,27 @@ namespace AdbcDrivers.BigQuery.MockServer
         private static Job CreateJobResource(MockJob mockJob)
         {
             long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var statistics = new JobStatistics
+            {
+                CreationTime = now,
+                StartTime = now,
+                EndTime = now,
+                Query = new JobStatistics2
+                {
+                    StatementType = "SELECT",
+                    TotalBytesProcessed = 0,
+                    TotalBytesBilled = 0,
+                }
+            };
+
+            if (mockJob.SessionId != null)
+            {
+                statistics.SessionInfo = new SessionInfo
+                {
+                    SessionId = mockJob.SessionId
+                };
+            }
+
             return new Job
             {
                 Kind = "bigquery#job",
@@ -309,18 +392,7 @@ namespace AdbcDrivers.BigQuery.MockServer
                         UseLegacySql = false,
                     },
                 },
-                Statistics = new JobStatistics
-                {
-                    CreationTime = now,
-                    StartTime = now,
-                    EndTime = now,
-                    Query = new JobStatistics2
-                    {
-                        StatementType = "SELECT",
-                        TotalBytesProcessed = 0,
-                        TotalBytesBilled = 0,
-                    }
-                }
+                Statistics = statistics
             };
         }
 
@@ -346,6 +418,7 @@ namespace AdbcDrivers.BigQuery.MockServer
             public string JobId { get; set; } = string.Empty;
             public string ProjectId { get; set; } = string.Empty;
             public string Status { get; set; } = "DONE";
+            public string? SessionId { get; set; }
         }
     }
 }

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/TransactionTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/TransactionTests.cs
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if NET8_0_OR_GREATER
+
+using System.Collections.Generic;
+using System.Linq;
+using Apache.Arrow.Adbc;
+using AdbcDrivers.BigQuery.MockServer;
+using Xunit;
+
+namespace AdbcDrivers.BigQuery.Tests.MockServer
+{
+    [Trait("Category", "MockServer")]
+    public class TransactionTests
+    {
+        private static (BigQueryMockServer server, AdbcConnection connection) CreateMockConnection()
+        {
+            var mockServer = new BigQueryMockServer();
+            string projectId = "mock-project";
+            var parameters = new Dictionary<string, string>
+            {
+                { BigQueryParameters.ProjectId, projectId },
+                { BigQueryParameters.AuthenticationType, BigQueryConstants.MockAuthenticationType },
+                { BigQueryParameters.TestRestEndpoint, mockServer.RestEndpoint },
+                { BigQueryParameters.TestStorageEndpoint, mockServer.GrpcEndpoint },
+            };
+
+            var driver = new BigQueryDriver();
+            AdbcDatabase database = driver.Open(parameters);
+            AdbcConnection connection = database.Connect(new Dictionary<string, string>());
+            return (mockServer, connection);
+        }
+
+        [Fact]
+        public void AutoCommit_IsEnabledByDefault()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                Assert.True(connection.AutoCommit);
+            }
+        }
+
+        [Fact]
+        public void AutoCommit_CanBeDisabled()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                connection.AutoCommit = false;
+
+                Assert.False(connection.AutoCommit);
+
+                // Should have executed: SELECT 1 (create session) and BEGIN TRANSACTION
+                Assert.Contains(server.ExecutedQueries, q => q == "SELECT 1");
+                Assert.Contains(server.ExecutedQueries, q => q == "BEGIN TRANSACTION");
+            }
+        }
+
+        [Fact]
+        public void AutoCommit_CanBeReEnabled()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                connection.AutoCommit = false;
+                connection.AutoCommit = true;
+
+                Assert.True(connection.AutoCommit);
+
+                // Should have executed COMMIT TRANSACTION and CALL BQ.ABORT_SESSION
+                Assert.Contains(server.ExecutedQueries, q => q == "COMMIT TRANSACTION");
+                Assert.Contains(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+            }
+        }
+
+        [Fact]
+        public void AutoCommit_DisableWhenAlreadyDisabled_Throws()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                connection.AutoCommit = false;
+
+                var ex = Assert.Throws<AdbcException>(() => connection.AutoCommit = false);
+                Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
+            }
+        }
+
+        [Fact]
+        public void AutoCommit_EnableWhenAlreadyEnabled_Throws()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                var ex = Assert.Throws<AdbcException>(() => connection.AutoCommit = true);
+                Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
+            }
+        }
+
+        [Fact]
+        public void Commit_WhenAutocommitEnabled_Throws()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                var ex = Assert.Throws<AdbcException>(() => connection.Commit());
+                Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
+            }
+        }
+
+        [Fact]
+        public void Rollback_WhenAutocommitEnabled_Throws()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                var ex = Assert.Throws<AdbcException>(() => connection.Rollback());
+                Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
+            }
+        }
+
+        [Fact]
+        public void Commit_ExecutesCommitAndBeginTransaction()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                connection.AutoCommit = false;
+
+                // Clear the queries recorded during setup
+                var queriesBefore = server.ExecutedQueries.Count;
+
+                connection.Commit();
+
+                // Get only the new queries after commit
+                var newQueries = server.ExecutedQueries.Skip(queriesBefore).ToList();
+                Assert.Equal(2, newQueries.Count);
+                Assert.Equal("COMMIT TRANSACTION", newQueries[0]);
+                Assert.Equal("BEGIN TRANSACTION", newQueries[1]);
+            }
+        }
+
+        [Fact]
+        public void Rollback_ExecutesRollbackAndBeginTransaction()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            using (connection)
+            {
+                connection.AutoCommit = false;
+
+                var queriesBefore = server.ExecutedQueries.Count;
+
+                connection.Rollback();
+
+                var newQueries = server.ExecutedQueries.Skip(queriesBefore).ToList();
+                Assert.Equal(2, newQueries.Count);
+                Assert.Equal("ROLLBACK TRANSACTION", newQueries[0]);
+                Assert.Equal("BEGIN TRANSACTION", newQueries[1]);
+            }
+        }
+
+        [Fact]
+        public void Dispose_WithActiveSession_AbortsSession()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            {
+                connection.AutoCommit = false;
+                connection.Dispose();
+
+                Assert.Contains(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+            }
+        }
+
+        [Fact]
+        public void Dispose_WithoutActiveSession_DoesNotAbortSession()
+        {
+            var (server, connection) = CreateMockConnection();
+            using (server)
+            {
+                connection.Dispose();
+
+                Assert.DoesNotContain(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+            }
+        }
+    }
+}
+
+#endif

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/TransactionTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/MockServer/TransactionTests.cs
@@ -16,6 +16,7 @@
 
 #if NET8_0_OR_GREATER
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Apache.Arrow.Adbc;
@@ -27,80 +28,54 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
     [Trait("Category", "MockServer")]
     public class TransactionTests
     {
-        private static (BigQueryMockServer server, AdbcConnection connection) CreateMockConnection()
-        {
-            var mockServer = new BigQueryMockServer();
-            string projectId = "mock-project";
-            var parameters = new Dictionary<string, string>
-            {
-                { BigQueryParameters.ProjectId, projectId },
-                { BigQueryParameters.AuthenticationType, BigQueryConstants.MockAuthenticationType },
-                { BigQueryParameters.TestRestEndpoint, mockServer.RestEndpoint },
-                { BigQueryParameters.TestStorageEndpoint, mockServer.GrpcEndpoint },
-            };
-
-            var driver = new BigQueryDriver();
-            AdbcDatabase database = driver.Open(parameters);
-            AdbcConnection connection = database.Connect(new Dictionary<string, string>());
-            return (mockServer, connection);
-        }
-
         [Fact]
         public void AutoCommit_IsEnabledByDefault()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                Assert.True(connection.AutoCommit);
+                Assert.True(resource.Connection.AutoCommit);
             }
         }
 
         [Fact]
         public void AutoCommit_CanBeDisabled()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
+                resource.Connection.AutoCommit = false;
 
-                Assert.False(connection.AutoCommit);
+                Assert.False(resource.Connection.AutoCommit);
 
                 // Should have executed: SELECT 1 (create session) and BEGIN TRANSACTION
-                Assert.Contains(server.ExecutedQueries, q => q == "SELECT 1");
-                Assert.Contains(server.ExecutedQueries, q => q == "BEGIN TRANSACTION");
+                Assert.Contains(resource.Server.ExecutedQueries, q => q == "SELECT 1");
+                Assert.Contains(resource.Server.ExecutedQueries, q => q == "BEGIN TRANSACTION");
             }
         }
 
         [Fact]
         public void AutoCommit_CanBeReEnabled()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
-                connection.AutoCommit = true;
+                resource.Connection.AutoCommit = false;
+                resource.Connection.AutoCommit = true;
 
-                Assert.True(connection.AutoCommit);
+                Assert.True(resource.Connection.AutoCommit);
 
                 // Should have executed COMMIT TRANSACTION and CALL BQ.ABORT_SESSION
-                Assert.Contains(server.ExecutedQueries, q => q == "COMMIT TRANSACTION");
-                Assert.Contains(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+                Assert.Contains(resource.Server.ExecutedQueries, q => q == "COMMIT TRANSACTION");
+                Assert.Contains(resource.Server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
             }
         }
 
         [Fact]
         public void AutoCommit_DisableWhenAlreadyDisabled_Throws()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
+                resource.Connection.AutoCommit = false;
 
-                var ex = Assert.Throws<AdbcException>(() => connection.AutoCommit = false);
+                var ex = Assert.Throws<AdbcException>(() => resource.Connection.AutoCommit = false);
                 Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
             }
         }
@@ -108,11 +83,9 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void AutoCommit_EnableWhenAlreadyEnabled_Throws()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                var ex = Assert.Throws<AdbcException>(() => connection.AutoCommit = true);
+                var ex = Assert.Throws<AdbcException>(() => resource.Connection.AutoCommit = true);
                 Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
             }
         }
@@ -120,11 +93,9 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void Commit_WhenAutocommitEnabled_Throws()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                var ex = Assert.Throws<AdbcException>(() => connection.Commit());
+                var ex = Assert.Throws<AdbcException>(() => resource.Connection.Commit());
                 Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
             }
         }
@@ -132,11 +103,9 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void Rollback_WhenAutocommitEnabled_Throws()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                var ex = Assert.Throws<AdbcException>(() => connection.Rollback());
+                var ex = Assert.Throws<AdbcException>(() => resource.Connection.Rollback());
                 Assert.Equal(AdbcStatusCode.InvalidState, ex.Status);
             }
         }
@@ -144,19 +113,17 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void Commit_ExecutesCommitAndBeginTransaction()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
+                resource.Connection.AutoCommit = false;
 
                 // Clear the queries recorded during setup
-                var queriesBefore = server.ExecutedQueries.Count;
+                var queriesBefore = resource.Server.ExecutedQueries.Count;
 
-                connection.Commit();
+                resource.Connection.Commit();
 
                 // Get only the new queries after commit
-                var newQueries = server.ExecutedQueries.Skip(queriesBefore).ToList();
+                var newQueries = resource.Server.ExecutedQueries.Skip(queriesBefore).ToList();
                 Assert.Equal(2, newQueries.Count);
                 Assert.Equal("COMMIT TRANSACTION", newQueries[0]);
                 Assert.Equal("BEGIN TRANSACTION", newQueries[1]);
@@ -166,17 +133,15 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void Rollback_ExecutesRollbackAndBeginTransaction()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
-            using (connection)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
+                resource.Connection.AutoCommit = false;
 
-                var queriesBefore = server.ExecutedQueries.Count;
+                var queriesBefore = resource.Server.ExecutedQueries.Count;
 
-                connection.Rollback();
+                resource.Connection.Rollback();
 
-                var newQueries = server.ExecutedQueries.Skip(queriesBefore).ToList();
+                var newQueries = resource.Server.ExecutedQueries.Skip(queriesBefore).ToList();
                 Assert.Equal(2, newQueries.Count);
                 Assert.Equal("ROLLBACK TRANSACTION", newQueries[0]);
                 Assert.Equal("BEGIN TRANSACTION", newQueries[1]);
@@ -186,25 +151,57 @@ namespace AdbcDrivers.BigQuery.Tests.MockServer
         [Fact]
         public void Dispose_WithActiveSession_AbortsSession()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
+            using (var resource = new BigQueryResource())
             {
-                connection.AutoCommit = false;
-                connection.Dispose();
+                resource.Connection.AutoCommit = false;
+                resource.Connection.Dispose();
 
-                Assert.Contains(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+                Assert.Contains(resource.Server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
             }
         }
 
         [Fact]
         public void Dispose_WithoutActiveSession_DoesNotAbortSession()
         {
-            var (server, connection) = CreateMockConnection();
-            using (server)
+            using (var resource = new BigQueryResource())
             {
-                connection.Dispose();
+                resource.Connection.Dispose();
 
-                Assert.DoesNotContain(server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+                Assert.DoesNotContain(resource.Server.ExecutedQueries, q => q.StartsWith("CALL BQ.ABORT_SESSION"));
+            }
+        }
+
+        class BigQueryResource : IDisposable
+        {
+            private readonly BigQueryMockServer _server;
+            private readonly AdbcDatabase _database;
+            private readonly AdbcConnection _connection;
+
+            public BigQueryResource()
+            {
+                _server = new BigQueryMockServer();
+                string projectId = "mock-project";
+                var parameters = new Dictionary<string, string>
+                {
+                    { BigQueryParameters.ProjectId, projectId },
+                    { BigQueryParameters.AuthenticationType, BigQueryConstants.MockAuthenticationType },
+                    { BigQueryParameters.TestRestEndpoint, _server.RestEndpoint },
+                    { BigQueryParameters.TestStorageEndpoint, _server.GrpcEndpoint },
+                };
+
+                var driver = new BigQueryDriver();
+                _database = driver.Open(parameters);
+                _connection = _database.Connect(new Dictionary<string, string>());
+            }
+
+            public BigQueryMockServer Server => _server;
+            public AdbcConnection Connection => _connection;
+
+            public void Dispose()
+            {
+                _connection.Dispose();
+                _database.Dispose();
+                _server.Dispose();
             }
         }
     }

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/TransactionLiveTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/TransactionLiveTests.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
-using Apache.Arrow.Types;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -99,8 +98,11 @@ namespace AdbcDrivers.BigQuery.Tests
                 RecordBatch? batch = result.Stream!.ReadNextRecordBatchAsync().GetAwaiter().GetResult();
                 if (batch != null)
                 {
-                    var countCol = (Int64Array)batch.Column(0);
-                    return countCol.GetValue(0)!.Value;
+                    using (batch)
+                    {
+                        var countCol = (Int64Array)batch.Column(0);
+                        return countCol.GetValue(0)!.Value;
+                    }
                 }
             }
             return -1;

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/TransactionLiveTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/TransactionLiveTests.cs
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using Apache.Arrow.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.BigQuery.Tests
+{
+    /// <summary>
+    /// Live integration tests for BigQuery transaction support.
+    /// Requires valid BigQuery credentials configured via BIGQUERY_TEST_CONFIG_FILE.
+    /// Each test creates and cleans up its own table.
+    /// </summary>
+    public class TransactionLiveTests : IDisposable
+    {
+        private readonly BigQueryTestConfiguration _testConfiguration;
+        private readonly List<BigQueryTestEnvironment> _environments;
+        private readonly ITestOutputHelper? _outputHelper;
+        private readonly List<(BigQueryTestEnvironment environment, string catalog, string dataset, string table)> _tablesToCleanup = new();
+
+        public TransactionLiveTests(ITestOutputHelper? outputHelper)
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(BigQueryTestingUtils.BIGQUERY_TEST_CONFIG_VARIABLE));
+
+            _testConfiguration = MultiEnvironmentTestUtils.LoadMultiEnvironmentTestConfiguration<BigQueryTestConfiguration>(BigQueryTestingUtils.BIGQUERY_TEST_CONFIG_VARIABLE);
+            _environments = MultiEnvironmentTestUtils.GetTestEnvironments<BigQueryTestEnvironment>(_testConfiguration);
+            _outputHelper = outputHelper;
+        }
+
+        public void Dispose()
+        {
+            foreach (var (environment, catalog, dataset, table) in _tablesToCleanup)
+            {
+                try
+                {
+                    using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                    using AdbcStatement stmt = connection.CreateStatement();
+                    stmt.SqlQuery = $"DROP TABLE IF EXISTS `{catalog}.{dataset}.{table}`";
+                    stmt.ExecuteUpdate();
+                    _outputHelper?.WriteLine($"Cleaned up table {catalog}.{dataset}.{table}");
+                }
+                catch (Exception ex)
+                {
+                    _outputHelper?.WriteLine($"Warning: failed to clean up table {catalog}.{dataset}.{table}: {ex.Message}");
+                }
+            }
+        }
+
+        private string UniqueTableName(string testName)
+        {
+            return $"adbc_txn_test_{testName}_{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+        }
+
+        private void EnsureTableDropped(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            using AdbcStatement stmt = connection.CreateStatement();
+            stmt.SqlQuery = $"DROP TABLE IF EXISTS `{catalog}.{dataset}.{tableName}`";
+            stmt.ExecuteUpdate();
+        }
+
+        private void RegisterCleanup(BigQueryTestEnvironment environment, string catalog, string dataset, string tableName)
+        {
+            _tablesToCleanup.Add((environment, catalog, dataset, tableName));
+        }
+
+        private void CreateTestTable(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            using AdbcStatement stmt = connection.CreateStatement();
+            stmt.SqlQuery = $"CREATE TABLE `{catalog}.{dataset}.{tableName}` (id INT64, name STRING)";
+            stmt.ExecuteUpdate();
+        }
+
+        private long CountRows(AdbcConnection connection, string catalog, string dataset, string tableName)
+        {
+            using AdbcStatement stmt = connection.CreateStatement();
+            stmt.SqlQuery = $"SELECT COUNT(*) AS cnt FROM `{catalog}.{dataset}.{tableName}`";
+            QueryResult result = stmt.ExecuteQuery();
+            using (result.Stream!)
+            {
+                RecordBatch? batch = result.Stream!.ReadNextRecordBatchAsync().GetAwaiter().GetResult();
+                if (batch != null)
+                {
+                    var countCol = (Int64Array)batch.Column(0);
+                    return countCol.GetValue(0)!.Value;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Verifies that autocommit can be disabled and re-enabled,
+        /// which creates and closes a BigQuery session.
+        /// </summary>
+        [SkippableFact]
+        public void CanDisableAndEnableAutoCommit()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+
+                Assert.True(connection.AutoCommit);
+
+                connection.AutoCommit = false;
+                Assert.False(connection.AutoCommit);
+
+                connection.AutoCommit = true;
+                Assert.True(connection.AutoCommit);
+
+                _outputHelper?.WriteLine($"[{environment.Name}] AutoCommit toggle succeeded");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a committed transaction persists data.
+        /// Creates a table, disables autocommit, inserts a row, commits,
+        /// re-enables autocommit, and verifies the row is visible.
+        /// </summary>
+        [SkippableFact]
+        public void CommitPersistsData()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("commit");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
+                CreateTestTable(connection, catalog, dataset, tableName);
+
+                // Disable autocommit to start a transaction
+                connection.AutoCommit = false;
+
+                using (AdbcStatement stmt = connection.CreateStatement())
+                {
+                    stmt.SqlQuery = $"INSERT INTO `{catalog}.{dataset}.{tableName}` (id, name) VALUES (1, 'committed')";
+                    stmt.ExecuteUpdate();
+                }
+
+                connection.Commit();
+
+                // Re-enable autocommit to close the session
+                connection.AutoCommit = true;
+
+                // Verify the row was persisted
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(1, rowCount);
+
+                _outputHelper?.WriteLine($"[{environment.Name}] Commit persisted {rowCount} row(s)");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a rolled-back transaction does not persist data.
+        /// Creates a table, disables autocommit, inserts a row, rolls back,
+        /// re-enables autocommit, and verifies the row is not visible.
+        /// </summary>
+        [SkippableFact]
+        public void RollbackDiscardsData()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("rollback");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
+                CreateTestTable(connection, catalog, dataset, tableName);
+
+                // Disable autocommit to start a transaction
+                connection.AutoCommit = false;
+
+                using (AdbcStatement stmt = connection.CreateStatement())
+                {
+                    stmt.SqlQuery = $"INSERT INTO `{catalog}.{dataset}.{tableName}` (id, name) VALUES (1, 'rolled_back')";
+                    stmt.ExecuteUpdate();
+                }
+
+                connection.Rollback();
+
+                // Re-enable autocommit to close the session
+                connection.AutoCommit = true;
+
+                // Verify the row was NOT persisted
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(0, rowCount);
+
+                _outputHelper?.WriteLine($"[{environment.Name}] Rollback discarded data as expected");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that multiple commits within a single session work correctly.
+        /// </summary>
+        [SkippableFact]
+        public void MultipleCommitsInOneSession()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                string catalog = environment.Metadata.Catalog;
+                string dataset = environment.Metadata.Schema;
+                string tableName = UniqueTableName("multi");
+
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+                EnsureTableDropped(connection, catalog, dataset, tableName);
+                RegisterCleanup(environment, catalog, dataset, tableName);
+                CreateTestTable(connection, catalog, dataset, tableName);
+
+                connection.AutoCommit = false;
+
+                // First transaction: insert row 1
+                using (AdbcStatement stmt = connection.CreateStatement())
+                {
+                    stmt.SqlQuery = $"INSERT INTO `{catalog}.{dataset}.{tableName}` (id, name) VALUES (1, 'first')";
+                    stmt.ExecuteUpdate();
+                }
+                connection.Commit();
+
+                // Second transaction: insert row 2
+                using (AdbcStatement stmt = connection.CreateStatement())
+                {
+                    stmt.SqlQuery = $"INSERT INTO `{catalog}.{dataset}.{tableName}` (id, name) VALUES (2, 'second')";
+                    stmt.ExecuteUpdate();
+                }
+                connection.Commit();
+
+                connection.AutoCommit = true;
+
+                long rowCount = CountRows(connection, catalog, dataset, tableName);
+                Assert.Equal(2, rowCount);
+
+                _outputHelper?.WriteLine($"[{environment.Name}] Multiple commits persisted {rowCount} row(s)");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that Commit and Rollback throw when autocommit is enabled.
+        /// </summary>
+        [SkippableFact]
+        public void CommitAndRollbackThrowWhenAutocommitEnabled()
+        {
+            foreach (BigQueryTestEnvironment environment in _environments)
+            {
+                using AdbcConnection connection = BigQueryTestingUtils.GetBigQueryAdbcConnection(environment);
+
+                Assert.Throws<AdbcException>(() => connection.Commit());
+                Assert.Throws<AdbcException>(() => connection.Rollback());
+
+                _outputHelper?.WriteLine($"[{environment.Name}] Commit/Rollback correctly rejected with autocommit on");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What's Changed

Add BigQuery session-based transaction support to the C# ADBC driver, matching the existing Go implementation pattern:

- BigQueryConnection: Add AutoCommit property override that creates/closes BigQuery sessions, and Commit/Rollback methods that issue COMMIT/ROLLBACK TRANSACTION and immediately BEGIN a new transaction
- BigQueryStatement: Pass session_id via ConnectionProperties in QueryOptions when a transaction is active, for both ExecuteQuery and ExecuteUpdate
- Tracing: Add session_id tags and lifecycle events (session_created, session_closed, transaction_started, transaction_committed, transaction_rolled_back) to all transaction operations and session-aware query execution via DiagnosticSource Activity tracing
- BigQueryMockServer: Add session tracking, parse CreateSession and ConnectionProperties from job requests, return SessionInfo in job stats
- TransactionTests: 11 mock server tests covering the full transaction lifecycle (enable/disable autocommit, commit, rollback, error cases, dispose)
- TransactionLiveTests: 5 live integration tests (skipped without credentials) covering commit persistence, rollback discard, multiple commits, and error cases against a real BigQuery instance