### PR TITLE
feat(csharp): add support for trace options in driver

### DIFF
--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -246,9 +247,26 @@ namespace AdbcDrivers.BigQuery
         private bool TryInitTracerProvider(out FileActivityListener? fileActivityListener)
         {
             properties.TryGetValue(ListenersOptions.Exporter, out string? exporterOption);
+            properties.TryGetValue(ListenersOptions.AdbcFile.Location, out string? adbcFileLocation);
+            properties.TryGetValue(ListenersOptions.AdbcFile.MaxTraceFileSizeKb, out string? maxTraceFileSizeKbOption);
+            properties.TryGetValue(ListenersOptions.AdbcFile.MaxTraceFiles, out string? maxTraceFilesOption);
+            long maxTraceFileSizeKb = long.TryParse(maxTraceFileSizeKbOption, NumberStyles.Integer, CultureInfo.InvariantCulture, out long parsedMaxTraceFileSizeKb) && parsedMaxTraceFileSizeKb > 0
+                ? parsedMaxTraceFileSizeKb
+                : FileActivityListener.MaxFileSizeKbDefault;
+            int maxTraceFiles = int.TryParse(maxTraceFilesOption, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedMaxTraceFiles) && parsedMaxTraceFiles > 0
+                ? parsedMaxTraceFiles
+                : FileActivityListener.MaxTraceFilesDefault;
+
             // This listener will only listen for activity from this specific connection instance.
             bool shouldListenTo(ActivitySource source) => source.Tags?.Any(t => ReferenceEquals(t.Key, _traceInstanceId)) == true;
-            return FileActivityListener.TryActivateFileListener(AssemblyName, exporterOption, out fileActivityListener, shouldListenTo: shouldListenTo);
+            return FileActivityListener.TryActivateFileListener(
+                AssemblyName,
+                exporterOption,
+                out fileActivityListener,
+                shouldListenTo: shouldListenTo,
+                tracesLocation: adbcFileLocation,
+                maxTraceFileSizeKb: maxTraceFileSizeKb,
+                maxTraceFiles: maxTraceFiles);
         }
 
         public override IEnumerable<KeyValuePair<string, object?>>? GetActivitySourceTags(IReadOnlyDictionary<string, string> properties)

--- a/csharp/src/AdbcDrivers.BigQuery/readme.md
+++ b/csharp/src/AdbcDrivers.BigQuery/readme.md
@@ -222,22 +222,25 @@ the connection is initialized.
 
 The following exporters are supported:
 
-| Exporter | Description |
-| --- | --- |
-| `adbcfile` | Exports traces to rotating files in a folder. |
+| Exporter | Description | Default Value |
+| :---     | :---        | :---          |
+| `adbc.traces.exporter` | Exports traces to rotating files in a folder. Supported: `adbcfile` | |
+| `adbc.traces.exporter.adbcfile.location` | The location where ADBC file traces will be stored. | See [File Exporter](#file-exporter) for `adbcflie` |
+| `adbc.traces.exporter.adbcfile.maxtracesizekb` | The maximum size of a single ADBC file trace in kilobytes. | `1024` |
+| `adbc.traces.exporter.adbcfile.maxtracefiles` | The maximum number of ADBC file traces to retain. | `999` |
 
-#### File Exporter (adbcfile)
+#### File Exporter
 
-Rotating trace files are written to a folder. The file names are created with the following pattern:
+For the `adbcfile` exporter, rotating trace files are written to a folder. The file names are created with the following pattern:
 `apache.arrow.adbc.drivers.bigquery-<YYYY-MM-DD-HH-mm-ss-fff>-<process-id>.log`.
 
 The folder used depends on the platform.
 
 | Platform | Folder |
-| --- | --- |
-| Windows | `%LOCALAPPDATA%/Apache.Arrow.Adbc/Traces` |
-| macOS   | `$HOME/Library/Application Support/Apache.Arrow.Adbc/Traces` |
-| Linux   | `$HOME/.local/share/Apache.Arrow.Adbc/Traces` |
+| ---      | ---    |
+| Windows  | `%LOCALAPPDATA%/Apache.Arrow.Adbc/Traces` |
+| macOS    | `$HOME/Library/Application Support/Apache.Arrow.Adbc/Traces` |
+| Linux    | `$HOME/.local/share/Apache.Arrow.Adbc/Traces` |
 
 By default, up to 999 files of maximum size 1024 KB are written to
 the trace folder.

--- a/csharp/src/AdbcDrivers.BigQuery/readme.md
+++ b/csharp/src/AdbcDrivers.BigQuery/readme.md
@@ -220,10 +220,10 @@ Use either the environment variable `OTEL_TRACES_EXPORTER` or the parameter `adb
 supported exporters. The parameter has precedence over the environment variable. The parameter must be set before
 the connection is initialized.
 
-The following exporters are supported:
+The following exporters are supported: `adbcfile`.
 
-| Exporter | Description | Default Value |
-| :---     | :---        | :---          |
+| Tracing Parameters | Description | Default Value |
+| :---               | :---        | :---          |
 | `adbc.traces.exporter` | Exports traces to rotating files in a folder. Supported: `adbcfile` | |
 | `adbc.traces.exporter.adbcfile.location` | The location where ADBC file traces will be stored. | See [File Exporter](#file-exporter) for `adbcflie` |
 | `adbc.traces.exporter.adbcfile.maxtracesizekb` | The maximum size of a single ADBC file trace in kilobytes. | `1024` |

--- a/csharp/src/AdbcDrivers.BigQuery/readme.md
+++ b/csharp/src/AdbcDrivers.BigQuery/readme.md
@@ -126,21 +126,21 @@ There are some limitations to both C# and the C# Arrow implementation that limit
 
 The following table depicts how the BigQuery ADBC driver converts a BigQuery type to an Arrow type.
 
-|  BigQuery Type   |      Arrow Type   | C# Type
-|----------|:-------------:|
-| BIGNUMERIC |    Decimal256    | string
-| BOOL |    Boolean   | bool
-| BYTES |    Binary   | byte[]
-| DATE |    Date32   | DateTime
-| DATETIME |    Timestamp   | DateTime
-| FLOAT64 |    Double   | double
-| GEOGRAPHY |    String   | string
-| INT64 |    Int64   | long
-| NUMERIC |    Decimal128   | SqlDecimal
-| STRING |    String   | string
-| STRUCT |    String+   | string
-| TIME |Time64   | long
-| TIMESTAMP |    Timestamp   | DateTimeOffset
+| BigQuery Type | Arrow Type | C# Type |
+| ----------    | :--------: | :---    |
+| BIGNUMERIC | Decimal256    | string |
+| BOOL       | Boolean       | bool |
+| BYTES      | Binary        | byte[] |
+| DATE       | Date32        | DateTime |
+| DATETIME   | Timestamp     | DateTime |
+| FLOAT64    | Double        | double |
+| GEOGRAPHY  | String        | string |
+| INT64      | Int64         | long |
+| NUMERIC    | Decimal128    | SqlDecimal |
+| STRING     | String        | string |
+| STRUCT     | String+       | string |
+| TIME       | Time64        | long |
+| TIMESTAMP  | Timestamp     | DateTimeOffset |
 
 +A JSON string
 

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/TelemetryTests.cs
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/TelemetryTests.cs
@@ -57,7 +57,8 @@ namespace AdbcDrivers.BigQuery.Tests
 
             foreach (BigQueryTestEnvironment environment in _environments)
             {
-                DirectoryInfo directoryInfo = GetTracesDirectoryInfo();
+                string tracesLocationSubfolder = Guid.NewGuid().ToString("N");
+                DirectoryInfo directoryInfo = GetTracesDirectoryInfo(tracesLocationSubfolder);
                 ResetTraceDirectory(directoryInfo);
 
                 directoryInfo.Refresh();
@@ -68,6 +69,7 @@ namespace AdbcDrivers.BigQuery.Tests
                 try
                 {
                     Dictionary<string, string> parameters = BigQueryTestingUtils.GetBigQueryParameters(environment);
+                    parameters[ListenersOptions.AdbcFile.Location] = directoryInfo.FullName;
                     using (AdbcDatabase database = new BigQueryDriver().Open(parameters))
                     {
                         try
@@ -118,10 +120,11 @@ namespace AdbcDrivers.BigQuery.Tests
             }
         }
 
-        private static DirectoryInfo GetTracesDirectoryInfo() =>
+        private static DirectoryInfo GetTracesDirectoryInfo(string tracesLocationFolder) =>
             new DirectoryInfo(Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "Apache.Arrow.Adbc",
-                "Traces"));
+                "Traces",
+                tracesLocationFolder));
     }
 }


### PR DESCRIPTION
## What's Changed

The motivation for adding these option to the drivers is 

1. that testing can be more reliable when the trace folders are not shared.
2. explicit location can help end-users choose where to find their trace files.

* Add three trace options via database/connection parameters.

| Property               | Description | Default |
| :---                   | :---        | :---    |
| `adbc.traces.exporter.adbcfile.location` | The location where ADBC file traces will be stored. | See [Tracing Support](#tracing-support) for `adbcflie` |
| `adbc.traces.exporter.adbcfile.maxtracesizekb` | The maximum size of a single ADBC file trace in kilobytes. | `1024` |
| `adbc.traces.exporter.adbcfile.maxtracefiles` | The maximum number of ADBC file traces to retain. | `999` |
