### PR TITLE
feat(csharp): add option to use Client without Quota Project to make meatdata calls

### DIFF
--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryConnection.cs
@@ -185,6 +185,8 @@ namespace AdbcDrivers.BigQuery
 
         internal BigQueryClient? Client { get; private set; }
 
+        internal BigQueryClient? ClientWithoutProject { get; private set; }
+
         /// <summary>
         /// The active BigQuery session ID when autocommit is disabled, or null when in autocommit mode.
         /// Used by <see cref="BigQueryStatement"/> to attach queries to the active session/transaction.
@@ -470,7 +472,42 @@ namespace AdbcDrivers.BigQuery
                     activity?.AddBigQueryTag("client.default_location", null);
                 }
 
+                GoogleCredential? credentialsForWithoutProjectClient = Credential?.CreateWithQuotaProject(null);
+
+                BigQueryClientBuilder bigQueryClientBuilderforWithoutProject = new BigQueryClientBuilder()
+                {
+                    GoogleCredential = credentialsForWithoutProjectClient
+                };
+
+                bigQueryClientBuilderforWithoutProject.ProjectId = !string.IsNullOrEmpty(billingProjectId) ? billingProjectId : projectId;
+
+                if (this.properties.TryGetValue(BigQueryParameters.TestRestEndpoint, out string? testRestEndpoint1) &&
+                    !string.IsNullOrEmpty(testRestEndpoint))
+                {
+                    bigQueryClientBuilderforWithoutProject.BaseUri = $"http://{testRestEndpoint1}/bigquery/v2/";
+                }
+
+                if (!string.IsNullOrEmpty(DefaultClientLocation))
+                {
+                    // If the user selects a public dataset (from a multi-region) but sets this
+                    // value to a specific location like us-east4, then there is an error produced
+                    // that the caller doesn't have permission to call to the public dataset.
+                    // Example:
+                    //    Access Denied: Table bigquery-public-data:blockchain_analytics_ethereum_mainnet_us.accounts:
+                    //    User does not have permission to query table bigquery-public-data:blockchain_analytics_ethereum_mainnet_us.accounts,
+                    //    or perhaps it does not exist.'
+
+                    bigQueryClientBuilderforWithoutProject.DefaultLocation = DefaultClientLocation;
+                    activity?.AddBigQueryParameterTag(BigQueryParameters.DefaultClientLocation, DefaultClientLocation);
+                }
+                else
+                {
+                    activity?.AddBigQueryTag("client.default_location", null);
+                }
+
+
                 BigQueryClient client = bigQueryClientBuilder.Build();
+                ClientWithoutProject = bigQueryClientBuilderforWithoutProject.Build();
 
                 if (clientTimeout.HasValue)
                 {

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryParameters.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryParameters.cs
@@ -61,6 +61,7 @@ namespace AdbcDrivers.BigQuery
         public const string StatementType = "adbc.bigquery.multiple_statement.statement_type";
         public const string UseLegacySQL = "adbc.bigquery.use_legacy_sql";
         public const string IsMetadataCommand = "adbc.bigquery.statement.is_metadata_command";
+        public const string UseClientWithoutProjectForMetadata = "adbc.bigquery.use_client_without_project_for_metadata";
 
         /// <summary>
         /// Overrides the BigQuery REST API endpoint for testing (e.g. "localhost:1234").

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -56,6 +56,7 @@ namespace AdbcDrivers.BigQuery
         readonly CancellationRegistry cancellationRegistry;
 
         bool isMetadataCommand = false;
+        bool useClientWithoutProjectForMetadata = false;
         string? catalogName = null;
         string? schemaName = null;
         string? tableName = null;
@@ -106,6 +107,8 @@ namespace AdbcDrivers.BigQuery
         }
 
         private BigQueryClient Client => this.bigQueryConnection.Client ?? throw new AdbcException("Client cannot be null");
+
+        private BigQueryClient ClientWithoutProject => this.bigQueryConnection.ClientWithoutProject ?? throw new AdbcException("ClientWithoutProject cannot be null");
 
         private GoogleCredential Credential => this.bigQueryConnection.Credential ?? throw new AdbcException("Credential cannot be null");
 
@@ -358,6 +361,10 @@ namespace AdbcDrivers.BigQuery
             StringArray.Builder tableTypeBuilder = new StringArray.Builder();
             Func<Task<PagedEnumerable<TableList, BigQueryTable>?>> func = () => Task.Run(() =>
             {
+                if (useClientWithoutProjectForMetadata)
+                {
+                    return ClientWithoutProject?.ListTables(this.catalogName, this.schemaName);
+                }
                 return Client?.ListTables(this.catalogName, this.schemaName);
             });
             PagedEnumerable<TableList, BigQueryTable>? tables;
@@ -413,6 +420,10 @@ namespace AdbcDrivers.BigQuery
 
             Func<Task<BigQueryTable?>> func = () => Task.Run(() =>
             {
+                if (useClientWithoutProjectForMetadata)
+                {
+                    return ClientWithoutProject?.GetTable(this.catalogName, this.schemaName, this.tableName);
+                }
                 return Client?.GetTable(this.catalogName, this.schemaName, this.tableName);
             });
 
@@ -514,6 +525,10 @@ namespace AdbcDrivers.BigQuery
 
             Func<Task<BigQueryTable?>> func = () => Task.Run(() =>
             {
+                if (useClientWithoutProjectForMetadata)
+                {
+                    return ClientWithoutProject?.GetTable(this.catalogName, this.schemaName, this.tableName);
+                }
                 return Client?.GetTable(this.catalogName, this.schemaName, this.tableName);
             });
             BigQueryTable? table = ExecuteWithRetriesAsync<BigQueryTable?>(func, activity).GetAwaiter().GetResult();
@@ -691,7 +706,12 @@ namespace AdbcDrivers.BigQuery
             Func<Task<PagedEnumerable<DatasetList, BigQueryDataset>?>> func = () => Task.Run(() =>
             {
                 // stick with this call because PagedAsyncEnumerable has different behaviors for selecting items
+                if (useClientWithoutProjectForMetadata)
+                {
+                    return ClientWithoutProject?.ListDatasets(this.catalogName);
+                }
                 return Client?.ListDatasets(this.catalogName);
+
             });
             PagedEnumerable<DatasetList, BigQueryDataset>? datasets;
             datasets = ExecuteWithRetriesAsync<PagedEnumerable<DatasetList, BigQueryDataset>?>(func, activity).GetAwaiter().GetResult();
@@ -725,7 +745,12 @@ namespace AdbcDrivers.BigQuery
             Func<Task<PagedEnumerable<ProjectList, CloudProject>?>> func = () => Task.Run(() =>
             {
                 // stick with this call because PagedAsyncEnumerable has different behaviors for selecting items
+                if (useClientWithoutProjectForMetadata)
+                {
+                    return ClientWithoutProject?.ListProjects();
+                }
                 return Client?.ListProjects();
+
             });
             PagedEnumerable<ProjectList, CloudProject>? catalogs;
             catalogs = ExecuteWithRetriesAsync<PagedEnumerable<ProjectList, CloudProject>?>(func, activity).GetAwaiter().GetResult();
@@ -1097,6 +1122,10 @@ namespace AdbcDrivers.BigQuery
                     case BigQueryParameters.IsMetadataCommand:
                         isMetadataCommand = keyValuePair.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
                         activity?.AddBigQueryParameterTag(BigQueryParameters.IsMetadataCommand, isMetadataCommand);
+                        break;
+                    case BigQueryParameters.UseClientWithoutProjectForMetadata:
+                        useClientWithoutProjectForMetadata = keyValuePair.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+                        activity?.AddBigQueryParameterTag(BigQueryParameters.UseClientWithoutProjectForMetadata, useClientWithoutProjectForMetadata);
                         break;
                     case BigQueryParameters.CatalogName:
                         catalogName = keyValuePair.Value;

--- a/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
+++ b/csharp/src/AdbcDrivers.BigQuery/BigQueryStatement.cs
@@ -56,7 +56,7 @@ namespace AdbcDrivers.BigQuery
         readonly CancellationRegistry cancellationRegistry;
 
         bool isMetadataCommand = false;
-        bool useClientWithoutProjectForMetadata = false;
+        bool useClientWithoutProjectForMetadata = true;
         string? catalogName = null;
         string? schemaName = null;
         string? tableName = null;


### PR DESCRIPTION
## What's Changed

This change creates a new option adbc.bigquery.use_client_without_project_for_metadata which if true then driver will use BigQueryClient without Project ID to do metadata calls. 

This looks like one  of the gaps that we have with ODBC BigQuery driver.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
