### PR TITLE
build(csharp): consume ADBC from nuget.org instead of the submodule

### DIFF
--- a/csharp/AdbcDrivers.BigQuery.sln
+++ b/csharp/AdbcDrivers.BigQuery.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdbcDrivers.BigQuery.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc", "arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj", "{8BFC2CBA-D9B9-C719-0617-59A21A7D7DF9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Telemetry.Traces.Listeners", "arrow-adbc\csharp\src\Telemetry\Traces\Listeners\Apache.Arrow.Adbc.Telemetry.Traces.Listeners.csproj", "{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Adbc.Testing", "arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj", "{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
@@ -37,10 +35,6 @@ Global
 		{8BFC2CBA-D9B9-C719-0617-59A21A7D7DF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BFC2CBA-D9B9-C719-0617-59A21A7D7DF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BFC2CBA-D9B9-C719-0617-59A21A7D7DF9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -59,7 +53,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8BFC2CBA-D9B9-C719-0617-59A21A7D7DF9} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-		{CE59B9B8-E2D9-68B5-D25D-6CC418E5BE00} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{9C9EDBEB-BAE2-E3C2-BD74-7E34C6AFEE51} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{80163E19-0794-37AE-1FA0-FFFA6A2DEC62} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -28,7 +28,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Apache.Arrow" Version="22.1.0" />
+    <PackageVersion Include="Apache.Arrow.Adbc" Version="0.24.0" />
     <PackageVersion Include="Apache.Arrow.Adbc.Drivers.BigQuery" Version="0.0.0" />
+    <PackageVersion Include="Apache.Arrow.Adbc.Telemetry.Traces.Listeners" Version="0.24.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Google.Cloud.BigQuery.Storage.V1" Version="3.17.0" />
     <PackageVersion Include="Google.Cloud.BigQuery.V2" Version="3.11.0" />

--- a/csharp/src/AdbcDrivers.BigQuery/AdbcDrivers.BigQuery.csproj
+++ b/csharp/src/AdbcDrivers.BigQuery/AdbcDrivers.BigQuery.csproj
@@ -10,8 +10,8 @@
 		<PackageReference Include="Google.Cloud.BigQuery.V2" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\..\arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj" />
-		<ProjectReference Include="..\..\arrow-adbc\csharp\src\Telemetry\Traces\Listeners\Apache.Arrow.Adbc.Telemetry.Traces.Listeners.csproj" />
+		<PackageReference Include="Apache.Arrow.Adbc" />
+		<PackageReference Include="Apache.Arrow.Adbc.Telemetry.Traces.Listeners" />
 	</ItemGroup>
 	<ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net6.0'))">
 		<PackageReference Include="System.Text.Json" />

--- a/csharp/test/AdbcDrivers.BigQuery.Tests/AdbcDrivers.BigQuery.Tests.csproj
+++ b/csharp/test/AdbcDrivers.BigQuery.Tests/AdbcDrivers.BigQuery.Tests.csproj
@@ -23,8 +23,16 @@
        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
      </None>
    </ItemGroup>
+   <!--
+     Apache.Arrow.Adbc.Testing is consumed from the arrow-adbc submodule rather
+     than from nuget.org: the published package ships only net8.0/net10.0
+     assets because upstream gates its net472 target on $(IsWindows), and this
+     suite targets net472 on Windows. The rest of the repo consumes ADBC from
+     nuget.org; this is the sole remaining submodule dependency, and it is
+     test-only, so it never reaches the published package's dependencies.
+     Apache.Arrow.Adbc.Client comes along transitively from Testing.
+   -->
    <ItemGroup>
-     <ProjectReference Include="..\..\arrow-adbc\csharp\src\Client\Apache.Arrow.Adbc.Client.csproj" />
      <ProjectReference Include="..\..\arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj" />
      <ProjectReference Include="..\..\src\AdbcDrivers.BigQuery\AdbcDrivers.BigQuery.csproj" />
      <ProjectReference Include="..\AdbcDrivers.BigQuery.MockServer\AdbcDrivers.BigQuery.MockServer.csproj" Condition="'$(TargetFramework)' == 'net8.0'" />


### PR DESCRIPTION
## What's Changed

Apache.Arrow.Adbc 0.24.0 and Apache.Arrow.Adbc.Telemetry.Traces.Listeners 0.24.0 are now published, so the driver references them as packages rather than as projects inside the csharp/arrow-adbc submodule. Packing the driver previously emitted dependencies on 0.24.0-SNAPSHOT, a version that does not exist on nuget.org, which made the resulting package uninstallable.

AdbcDrivers.BigQuery.Tests keeps its ProjectReference to the submodule's Apache.Arrow.Adbc.Testing. The published Testing package ships only net8.0/net10.0 assets because upstream gates its net472 target on $(IsWindows), and this suite targets net472 on Windows. Apache.Arrow.Adbc.Client now comes along transitively from Testing rather than being referenced directly. The submodule is therefore now test-only, and no longer reaches any published artifact.